### PR TITLE
Enhance keyboard shortcuts with task navigation and add missing i18n …

### DIFF
--- a/__tests__/useGradingShortcuts.test.ts
+++ b/__tests__/useGradingShortcuts.test.ts
@@ -72,6 +72,40 @@ describe('useGradingShortcuts', () => {
     expect(onToggleComplete).toHaveBeenCalledTimes(1);
   });
 
+  it('calls onNextTask for Tab', () => {
+    const onNextTask = vi.fn();
+    renderHook(() => useGradingShortcuts({ onNextTask, enabled: true }));
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+    expect(onNextTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onPreviousTask for Shift+Tab', () => {
+    const onPreviousTask = vi.fn();
+    renderHook(() => useGradingShortcuts({ onPreviousTask, enabled: true }));
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
+    expect(onPreviousTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onFocusComment for Enter (not Alt)', () => {
+    const onFocusComment = vi.fn();
+    renderHook(() => useGradingShortcuts({ onFocusComment, enabled: true }));
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(onFocusComment).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onFocusComment for Alt+Enter (that is toggleComplete)', () => {
+    const onFocusComment = vi.fn();
+    const onToggleComplete = vi.fn();
+    renderHook(() => useGradingShortcuts({ onFocusComment, onToggleComplete, enabled: true }));
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', altKey: true }));
+    expect(onFocusComment).not.toHaveBeenCalled();
+    expect(onToggleComplete).toHaveBeenCalledTimes(1);
+  });
+
   it('cleans up on unmount', () => {
     const { unmount } = renderHook(() => useGradingShortcuts({ enabled: true }));
     unmount();

--- a/components/GradingProgressBar.tsx
+++ b/components/GradingProgressBar.tsx
@@ -18,7 +18,7 @@ export default function GradingProgressBar({ completedCount, totalCount }: Gradi
     <div className="bg-surface rounded-lg shadow-sm p-4 mb-6 border border-border">
       <div className="flex items-center justify-between mb-2">
         <span className="text-sm font-medium text-text-primary">
-          {t('test.gradingProgress') || 'Grading progress'}
+          {t('test.gradingProgress')}
         </span>
         <span className="text-sm font-semibold text-text-primary tabular-nums">
           {completedCount} / {totalCount} ({percentage}%)
@@ -38,7 +38,7 @@ export default function GradingProgressBar({ completedCount, totalCount }: Gradi
       </div>
       {percentage === 100 && (
         <p className="text-xs text-success mt-1 font-medium">
-          {t('test.allStudentsGraded') || 'All students graded!'}
+          {t('test.allStudentsGraded')}
         </p>
       )}
     </div>

--- a/hooks/useGradingShortcuts.ts
+++ b/hooks/useGradingShortcuts.ts
@@ -1,16 +1,28 @@
 import { useEffect, useCallback } from 'react';
 
+export interface TaskSlot {
+  taskId: string;
+  subtaskId?: string;
+}
+
 interface UseGradingShortcutsOptions {
   onSetPoints?: (points: number) => void;
   onNextStudent?: () => void;
   onPreviousStudent?: () => void;
   onToggleComplete?: () => void;
+  onNextTask?: () => void;
+  onPreviousTask?: () => void;
+  onFocusComment?: () => void;
+  onFocusPoints?: () => void;
   enabled?: boolean;
 }
 
 /**
  * Keyboard shortcuts for the grading interface:
- * - 0-6: Set points for the focused task
+ * - 0-6: Set points for the active task
+ * - Tab / Shift+Tab: Next / previous task
+ * - Enter: Switch from points to comment (when not in textarea)
+ * - Escape: Switch from comment back to points
  * - Alt+ArrowRight / Alt+ArrowDown: Next student
  * - Alt+ArrowLeft / Alt+ArrowUp: Previous student
  * - Alt+Enter: Toggle complete
@@ -20,28 +32,22 @@ export function useGradingShortcuts({
   onNextStudent,
   onPreviousStudent,
   onToggleComplete,
+  onNextTask,
+  onPreviousTask,
+  onFocusComment,
+  onFocusPoints,
   enabled = true,
 }: UseGradingShortcutsOptions) {
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (!enabled) return;
 
-    // Don't trigger shortcuts when typing in text inputs/textareas
     const target = e.target as HTMLElement;
-    const isTextInput = target.tagName === 'TEXTAREA' ||
+    const isTextarea = target.tagName === 'TEXTAREA';
+    const isTextInput = isTextarea ||
       (target.tagName === 'INPUT' && (target as HTMLInputElement).type === 'text') ||
       target.isContentEditable;
 
-    // Number keys 0-6 for setting points (only when not typing in text fields)
-    if (!isTextInput && !e.altKey && !e.ctrlKey && !e.metaKey) {
-      const num = parseInt(e.key);
-      if (num >= 0 && num <= 6 && onSetPoints) {
-        e.preventDefault();
-        onSetPoints(num);
-        return;
-      }
-    }
-
-    // Alt+Arrow navigation for students
+    // Alt+key combinations (work everywhere)
     if (e.altKey && !e.ctrlKey && !e.metaKey) {
       if ((e.key === 'ArrowRight' || e.key === 'ArrowDown') && onNextStudent) {
         e.preventDefault();
@@ -59,7 +65,49 @@ export function useGradingShortcuts({
         return;
       }
     }
-  }, [enabled, onSetPoints, onNextStudent, onPreviousStudent, onToggleComplete]);
+
+    // Escape from textarea: go back to points mode
+    if (isTextarea && e.key === 'Escape' && onFocusPoints) {
+      e.preventDefault();
+      (target as HTMLTextAreaElement).blur();
+      onFocusPoints();
+      return;
+    }
+
+    // Don't trigger remaining shortcuts when typing in text fields
+    if (isTextInput) return;
+
+    // Number keys 0-6 for setting points
+    if (!e.altKey && !e.ctrlKey && !e.metaKey) {
+      const num = parseInt(e.key);
+      if (num >= 0 && num <= 6 && onSetPoints) {
+        e.preventDefault();
+        onSetPoints(num);
+        return;
+      }
+    }
+
+    // Tab / Shift+Tab for task navigation
+    if (e.key === 'Tab' && !e.altKey && !e.ctrlKey && !e.metaKey) {
+      if (e.shiftKey && onPreviousTask) {
+        e.preventDefault();
+        onPreviousTask();
+        return;
+      }
+      if (!e.shiftKey && onNextTask) {
+        e.preventDefault();
+        onNextTask();
+        return;
+      }
+    }
+
+    // Enter to switch to comment textarea
+    if (e.key === 'Enter' && !e.altKey && !e.ctrlKey && !e.metaKey && onFocusComment) {
+      e.preventDefault();
+      onFocusComment();
+      return;
+    }
+  }, [enabled, onSetPoints, onNextStudent, onPreviousStudent, onToggleComplete, onNextTask, onPreviousTask, onFocusComment, onFocusPoints]);
 
   useEffect(() => {
     if (!enabled) return;

--- a/locales/en.json
+++ b/locales/en.json
@@ -263,7 +263,18 @@
     "noTasksMatch": "No tasks match the selected filters",
     "analyticsNote": "Note: Avg Score is average points earned across all students who attempted the task. Attempt % is percentage of students who scored 1 or more points.",
     "previousStudent": "Previous Student",
-    "nextStudent": "Next Student"
+    "nextStudent": "Next Student",
+    "keyboardShortcuts": "Keyboard Shortcuts",
+    "shortcutSetPoints": "Set points for active task",
+    "shortcutNextTask": "Next task",
+    "shortcutPrevTask": "Previous task",
+    "shortcutFocusComment": "Write comment",
+    "shortcutFocusPoints": "Back to points",
+    "shortcutPrevStudent": "Previous student",
+    "shortcutNextStudent": "Next student",
+    "shortcutToggleComplete": "Toggle complete",
+    "gradingProgress": "Grading Progress",
+    "allStudentsGraded": "All students graded!"
   },
   "oral": {
     "title": "Oral Assessment",

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -263,7 +263,18 @@
     "noTasksMatch": "Ingen oppgaver passer de valgte filtrene",
     "analyticsNote": "Merk: Gj.snitt poeng er gjennomsnittlig poeng tjent på tvers av alle elever som forsøkte oppgaven. Forsøk % er prosentdel av elever som skåret 1 eller flere poeng.",
     "previousStudent": "Forrige elev",
-    "nextStudent": "Neste elev"
+    "nextStudent": "Neste elev",
+    "keyboardShortcuts": "Tastatursnarveier",
+    "shortcutSetPoints": "Sett poeng for aktiv oppgave",
+    "shortcutNextTask": "Neste oppgave",
+    "shortcutPrevTask": "Forrige oppgave",
+    "shortcutFocusComment": "Skriv kommentar",
+    "shortcutFocusPoints": "Tilbake til poeng",
+    "shortcutPrevStudent": "Forrige elev",
+    "shortcutNextStudent": "Neste elev",
+    "shortcutToggleComplete": "Skift fullføringsstatus",
+    "gradingProgress": "Retteframgang",
+    "allStudentsGraded": "Alle elever er rettet!"
   },
   "oral": {
     "title": "Muntlig vurdering",

--- a/locales/nn.json
+++ b/locales/nn.json
@@ -263,7 +263,18 @@
     "noTasksMatch": "Ingen oppgåver passar dei valde filtera",
     "analyticsNote": "Merk: Gj.snitt poeng er gjennomsnittleg poeng tjent på tvers av alle elevar som forsøkte oppgåva. Forsøk % er prosentdel av elevar som skåra 1 eller fleire poeng.",
     "previousStudent": "Førre elev",
-    "nextStudent": "Neste elev"
+    "nextStudent": "Neste elev",
+    "keyboardShortcuts": "Tastatursnarvegar",
+    "shortcutSetPoints": "Set poeng for aktiv oppgåve",
+    "shortcutNextTask": "Neste oppgåve",
+    "shortcutPrevTask": "Førre oppgåve",
+    "shortcutFocusComment": "Skriv kommentar",
+    "shortcutFocusPoints": "Tilbake til poeng",
+    "shortcutPrevStudent": "Førre elev",
+    "shortcutNextStudent": "Neste elev",
+    "shortcutToggleComplete": "Skift fullføringsstatus",
+    "gradingProgress": "Retteframgang",
+    "allStudentsGraded": "Alle elevar er retta!"
   },
   "oral": {
     "title": "Munnleg vurdering",


### PR DESCRIPTION
…keys

- Add Tab/Shift+Tab to navigate between tasks within a student
- Add Enter to focus the comment textarea for the active task
- Add Escape to return from comment to points mode
- Highlight the active task with a visual ring indicator
- Add all missing translation keys to nn/nb/en locale files: keyboardShortcuts, shortcutSetPoints, shortcutNextTask, shortcutPrevTask, shortcutFocusComment, shortcutFocusPoints, shortcutPrevStudent, shortcutNextStudent, shortcutToggleComplete, gradingProgress, allStudentsGraded
- Remove hardcoded English fallbacks from GradingProgressBar
- Update keyboard shortcut help popover with styled <kbd> elements
- Update tests to cover new Tab/Enter/Escape shortcuts (38 total)

https://claude.ai/code/session_01LeSj1e3urhNtFPSHJLiXFA