### PR TITLE
Rebrand color palette from blue to indigo with updated design tokens

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -82,14 +82,14 @@ export default function AnalyticsPage() {
             <div className="bg-white rounded-lg shadow-md p-6">
               <div className="flex items-center justify-between mb-6">
                 <div className="flex items-center gap-3">
-                  <BarChart3 size={28} className="text-purple-600" />
+                  <BarChart3 size={28} className="text-indigo-600" />
                   <h2 className="text-2xl font-display font-bold text-gray-800">Task Difficulty Analysis</h2>
                 </div>
                 <div>
                   <select
                     value={selectedTest}
                     onChange={(e) => setSelectedTest(e.target.value)}
-                    className="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
+                    className="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
                   >
                     <option value="">All Tests</option>
                     {testNames.map(name => (
@@ -220,9 +220,9 @@ export default function AnalyticsPage() {
                         {studentData.averageScore.toFixed(1)}%
                       </p>
                     </div>
-                    <div className="bg-purple-50 rounded-lg p-4 border border-purple-200">
-                      <h3 className="text-sm font-medium text-purple-800 mb-1">Latest Score</h3>
-                      <p className="text-3xl font-display font-bold text-purple-600">
+                    <div className="bg-indigo-50 rounded-lg p-4 border border-indigo-200">
+                      <h3 className="text-sm font-medium text-indigo-800 mb-1">Latest Score</h3>
+                      <p className="text-3xl font-display font-bold text-indigo-600">
                         {studentData.feedbacks.length > 0
                           ? ((studentData.feedbacks[studentData.feedbacks.length - 1].totalPoints /
                               studentData.feedbacks[studentData.feedbacks.length - 1].maxPoints) *

--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -11,17 +11,23 @@ export default function AppleIcon() {
     (
       <div
         style={{
-          fontSize: 140,
           width: '100%',
           height: '100%',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          background: 'white',
+          background: '#4F46E5',
           borderRadius: 36,
         }}
       >
-        🎓
+        <div style={{
+          fontSize: 110,
+          fontWeight: 800,
+          color: 'white',
+          letterSpacing: '-0.05em',
+        }}>
+          M
+        </div>
       </div>
     ),
     {

--- a/app/archive/page.tsx
+++ b/app/archive/page.tsx
@@ -88,7 +88,7 @@ export default function ArchivePage() {
           <div>
             <Link
               href="/"
-              className="inline-flex items-center gap-2 text-brand hover:text-rose-800 mb-4"
+              className="inline-flex items-center gap-2 text-brand hover:text-brand-hover mb-4"
             >
               <ArrowLeft size={20} />
               Back to Feedback

--- a/app/course/[courseId]/analytics/page.tsx
+++ b/app/course/[courseId]/analytics/page.tsx
@@ -63,7 +63,7 @@ export default function CourseAnalyticsPage() {
         <div className="mb-6">
           <Link
             href={`/course/${courseId}`}
-            className="inline-flex items-center gap-2 text-brand hover:text-rose-800 mb-2"
+            className="inline-flex items-center gap-2 text-brand hover:text-brand-hover mb-2"
           >
             <ArrowLeft size={20} />
             {t('analytics.backToCourse')}
@@ -101,10 +101,10 @@ export default function CourseAnalyticsPage() {
           {course.oralTests && course.oralTests.length > 0 && (
             <div className="bg-surface rounded-lg shadow-sm p-4">
               <div className="flex items-center gap-2 mb-2">
-                <UserCircle size={20} className="text-violet-600" />
+                <UserCircle size={20} className="text-indigo-600" />
                 <h3 className="font-semibold text-text-primary">{t('course.oralTests')}</h3>
               </div>
-              <p className="text-3xl font-display font-bold text-violet-600">{course.oralTests.length}</p>
+              <p className="text-3xl font-display font-bold text-indigo-600">{course.oralTests.length}</p>
             </div>
           )}
         </div>
@@ -113,7 +113,7 @@ export default function CourseAnalyticsPage() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
           {/* Test Analytics Links */}
           {course.tests.length > 0 && (
-            <div className="bg-surface rounded-lg shadow-sm p-6 border-2 border-violet-200">
+            <div className="bg-surface rounded-lg shadow-sm p-6 border-2 border-indigo-200">
               <div className="flex items-center gap-2 mb-4">
                 <FileText size={24} className="text-brand" />
                 <h2 className="text-xl font-display font-bold text-text-primary">{t('test.taskAnalyticsTitle')}</h2>
@@ -128,7 +128,7 @@ export default function CourseAnalyticsPage() {
                       <Link
                         key={test.id}
                         href={`/course/${courseId}/test/${test.id}/analytics`}
-                        className="block p-3 border border-border rounded-lg hover:border-brand hover:bg-violet-50 transition-all group"
+                        className="block p-3 border border-border rounded-lg hover:border-brand hover:bg-indigo-50 transition-all group"
                       >
                         <div className="flex items-center justify-between">
                           <div className="flex-1">
@@ -208,8 +208,8 @@ export default function CourseAnalyticsPage() {
                       key={lp.label}
                       className={`p-3 rounded-lg border-2 transition-colors cursor-pointer ${
                         selectedLabel === lp.label
-                          ? 'border-violet-600 bg-violet-50'
-                          : 'border-border hover:border-violet-300'
+                          ? 'border-indigo-600 bg-indigo-50'
+                          : 'border-border hover:border-indigo-300'
                       }`}
                       onClick={() => setSelectedLabel(lp.label === selectedLabel ? null : lp.label)}
                     >
@@ -375,9 +375,9 @@ export default function CourseAnalyticsPage() {
         )}
 
         {/* Help Section */}
-        <div className="mt-6 bg-violet-50 border border-violet-200 rounded-lg p-4">
-          <h3 className="font-semibold text-violet-900 mb-2">{t('analytics.howToUseAnalytics')}</h3>
-          <ul className="text-sm text-violet-800 space-y-1">
+        <div className="mt-6 bg-indigo-50 border border-indigo-200 rounded-lg p-4">
+          <h3 className="font-semibold text-indigo-900 mb-2">{t('analytics.howToUseAnalytics')}</h3>
+          <ul className="text-sm text-indigo-800 space-y-1">
             <li>• {t('analytics.analyticsHelp1')}</li>
             <li>• {t('analytics.analyticsHelp2')}</li>
             <li>• {t('analytics.analyticsHelp3')}</li>

--- a/app/course/[courseId]/oral/[oralTestId]/page.tsx
+++ b/app/course/[courseId]/oral/[oralTestId]/page.tsx
@@ -196,13 +196,13 @@ export default function OralAssessmentPage() {
           <div>
             <Link
               href={`/course/${courseId}`}
-              className="inline-flex items-center gap-2 text-purple-600 hover:text-purple-800 mb-2"
+              className="inline-flex items-center gap-2 text-indigo-600 hover:text-indigo-800 mb-2"
             >
               <ArrowLeft size={20} />
               {t('test.backToCourse')}
             </Link>
             <div className="flex items-center gap-3">
-              <MessageSquare size={28} className="text-purple-600" />
+              <MessageSquare size={28} className="text-indigo-600" />
               <div>
                 <div className="flex items-center gap-4">
                   <h1 className="text-3xl font-display font-bold text-text-primary">{oralTest.name}</h1>
@@ -210,7 +210,7 @@ export default function OralAssessmentPage() {
                     <select
                       value={oralTestId}
                       onChange={(e) => router.push(`/course/${courseId}/oral/${e.target.value}`)}
-                      className="px-3 py-2 border border-border rounded-lg bg-surface text-text-primary hover:border-purple-600 focus:outline-none focus:ring-2 focus:ring-purple-600 transition-all cursor-pointer"
+                      className="px-3 py-2 border border-border rounded-lg bg-surface text-text-primary hover:border-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-600 transition-all cursor-pointer"
                     >
                       {course.oralTests.map(ot => (
                         <option key={ot.id} value={ot.id}>
@@ -222,7 +222,7 @@ export default function OralAssessmentPage() {
                 </div>
                 {oralTest.description && <p className="text-text-secondary">{oralTest.description}</p>}
                 {oralTest.topics && oralTest.topics.length > 0 && (
-                  <p className="text-sm text-purple-600 mt-1">
+                  <p className="text-sm text-indigo-600 mt-1">
                     {t('course.topics')}: {oralTest.topics.join(', ')}
                   </p>
                 )}
@@ -260,8 +260,8 @@ export default function OralAssessmentPage() {
                         onClick={() => setSelectedStudent(student)}
                         className={`w-full text-left p-3 rounded-lg border transition-all ${
                           isSelected
-                            ? 'bg-purple-100 border-purple-500 shadow-md'
-                            : 'bg-background border-border hover:border-purple-300 hover:bg-purple-50'
+                            ? 'bg-indigo-100 border-indigo-500 shadow-md'
+                            : 'bg-background border-border hover:border-indigo-300 hover:bg-indigo-50'
                         }`}
                       >
                         <div className="flex items-center justify-between mb-1">
@@ -288,7 +288,7 @@ export default function OralAssessmentPage() {
 
               <Link
                 href={`/course/${courseId}/analytics`}
-                className="mt-4 flex items-center justify-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition w-full text-sm"
+                className="mt-4 flex items-center justify-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition w-full text-sm"
               >
                 <BarChart3 size={16} />
                 {t('course.viewAnalytics')}
@@ -300,7 +300,7 @@ export default function OralAssessmentPage() {
           <div className="lg:col-span-9">
             {!selectedStudent ? (
               <div className="bg-surface rounded-lg shadow-sm p-12 text-center">
-                <MessageSquare size={48} className="mx-auto text-purple-300 mb-4" />
+                <MessageSquare size={48} className="mx-auto text-indigo-300 mb-4" />
                 <p className="text-text-secondary text-lg">{t('test.selectStudentPrompt')}</p>
               </div>
             ) : (
@@ -313,7 +313,7 @@ export default function OralAssessmentPage() {
                     <button
                       onClick={handleSave}
                       disabled={isSaving}
-                      className="flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition disabled:opacity-50"
+                      className="flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition disabled:opacity-50"
                     >
                       <Save size={18} />
                       {t('common.save')}

--- a/app/course/[courseId]/page.tsx
+++ b/app/course/[courseId]/page.tsx
@@ -404,7 +404,7 @@ export default function CourseDetailPage() {
           <div>
             <Link
               href="/courses"
-              className="inline-flex items-center gap-2 text-brand hover:text-rose-800 mb-2"
+              className="inline-flex items-center gap-2 text-brand hover:text-brand-hover mb-2"
             >
               <ArrowLeft size={20} />
               {t('course.backToCourses')}
@@ -492,7 +492,7 @@ export default function CourseDetailPage() {
               </div>
               <div>
                 <p className="text-text-secondary">{t('course.possibleFeedback')}</p>
-                <p className="text-2xl font-display font-bold text-violet-700">
+                <p className="text-2xl font-display font-bold text-indigo-700">
                   {course.students.length * course.tests.length}
                 </p>
               </div>
@@ -580,7 +580,7 @@ export default function CourseDetailPage() {
                     value={bulkStudentText}
                     onChange={(e) => setBulkStudentText(e.target.value)}
                     rows={10}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-violet-500 text-text-primary font-mono text-sm"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary font-mono text-sm"
                     placeholder={t('course.bulkAddPlaceholder')}
                     autoFocus
                   />
@@ -794,7 +794,7 @@ export default function CourseDetailPage() {
                     type="text"
                     value={newOralTestName}
                     onChange={(e) => setNewOralTestName(e.target.value)}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary"
                     placeholder={t('course.oralTestNamePlaceholder')}
                     autoFocus
                   />
@@ -808,7 +808,7 @@ export default function CourseDetailPage() {
                     type="text"
                     value={newOralTestDescription}
                     onChange={(e) => setNewOralTestDescription(e.target.value)}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary"
                     placeholder={t('course.oralTestDescriptionPlaceholder')}
                   />
                 </div>
@@ -821,7 +821,7 @@ export default function CourseDetailPage() {
                     type="date"
                     value={newOralTestDate}
                     onChange={(e) => setNewOralTestDate(e.target.value)}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary"
                   />
                 </div>
 
@@ -833,7 +833,7 @@ export default function CourseDetailPage() {
                     type="text"
                     value={newOralTestTopics}
                     onChange={(e) => setNewOralTestTopics(e.target.value)}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary"
                     placeholder={t('course.oralTestTopicsPlaceholder')}
                   />
                   <p className="text-xs text-text-disabled mt-1">
@@ -861,8 +861,8 @@ export default function CourseDetailPage() {
                           }}
                           className={`px-3 py-1 rounded-full text-sm transition ${
                             newOralTestLabels.includes(label)
-                              ? 'bg-purple-600 text-white'
-                              : 'bg-purple-100 text-purple-800 hover:bg-purple-200'
+                              ? 'bg-indigo-600 text-white'
+                              : 'bg-indigo-100 text-indigo-800 hover:bg-indigo-200'
                           }`}
                         >
                           {label}
@@ -889,7 +889,7 @@ export default function CourseDetailPage() {
                 </button>
                 <button
                   onClick={handleAddOralTest}
-                  className="flex-1 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition"
+                  className="flex-1 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition"
                 >
                   {t('course.addOralTestButton')}
                 </button>
@@ -1032,7 +1032,7 @@ export default function CourseDetailPage() {
                     type="text"
                     value={newOralTestName}
                     onChange={(e) => setNewOralTestName(e.target.value)}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary"
                     autoFocus
                   />
                 </div>
@@ -1045,7 +1045,7 @@ export default function CourseDetailPage() {
                     type="text"
                     value={newOralTestDescription}
                     onChange={(e) => setNewOralTestDescription(e.target.value)}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary"
                     placeholder={t('course.oralTestDescriptionPlaceholder')}
                   />
                 </div>
@@ -1058,7 +1058,7 @@ export default function CourseDetailPage() {
                     type="date"
                     value={newOralTestDate}
                     onChange={(e) => setNewOralTestDate(e.target.value)}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary"
                   />
                 </div>
 
@@ -1070,7 +1070,7 @@ export default function CourseDetailPage() {
                     type="text"
                     value={newOralTestTopics}
                     onChange={(e) => setNewOralTestTopics(e.target.value)}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary"
                     placeholder={t('course.oralTestTopicsPlaceholder')}
                   />
                   <p className="text-xs text-text-disabled mt-1">
@@ -1098,8 +1098,8 @@ export default function CourseDetailPage() {
                           }}
                           className={`px-3 py-1 rounded-full text-sm transition ${
                             newOralTestLabels.includes(label)
-                              ? 'bg-purple-600 text-white'
-                              : 'bg-purple-100 text-purple-800 hover:bg-purple-200'
+                              ? 'bg-indigo-600 text-white'
+                              : 'bg-indigo-100 text-indigo-800 hover:bg-indigo-200'
                           }`}
                         >
                           {label}
@@ -1122,7 +1122,7 @@ export default function CourseDetailPage() {
                 </button>
                 <button
                   onClick={handleUpdateOralTest}
-                  className="flex-1 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition"
+                  className="flex-1 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition"
                 >
                   {t('common.save')}
                 </button>

--- a/app/course/[courseId]/student/[studentId]/page.tsx
+++ b/app/course/[courseId]/student/[studentId]/page.tsx
@@ -65,7 +65,7 @@ export default function StudentDashboardPage() {
         <div className="mb-6">
           <Link
             href={`/course/${courseId}`}
-            className="inline-flex items-center gap-2 text-brand hover:text-rose-800 mb-2"
+            className="inline-flex items-center gap-2 text-brand hover:text-brand-hover mb-2"
           >
             <ArrowLeft size={20} />
             {t('common.back')}
@@ -243,7 +243,7 @@ export default function StudentDashboardPage() {
         {/* Oral Assessments Performance */}
         <div className="bg-surface rounded-lg shadow-sm p-6 mb-6">
           <div className="flex items-center gap-2 mb-4">
-            <MessageSquare size={24} className="text-purple-600" />
+            <MessageSquare size={24} className="text-indigo-600" />
             <h2 className="text-2xl font-display font-bold text-text-primary">{t('course.oralTests')}</h2>
           </div>
 
@@ -256,11 +256,11 @@ export default function StudentDashboardPage() {
                     {/* Oral test card - 50% width */}
                     <Link
                       href={`/course/${courseId}/oral/${oral.oralTestId}?student=${studentId}`}
-                      className="flex-[0.50] border border-border rounded-lg p-4 hover:border-purple-500 hover:shadow-sm transition-colors cursor-pointer"
+                      className="flex-[0.50] border border-border rounded-lg p-4 hover:border-indigo-500 hover:shadow-sm transition-colors cursor-pointer"
                     >
                       <div className="flex items-center justify-between mb-2">
                         <div>
-                          <h4 className="font-semibold text-text-primary hover:text-purple-600 transition-colors">{oral.oralTestName}</h4>
+                          <h4 className="font-semibold text-text-primary hover:text-indigo-600 transition-colors">{oral.oralTestName}</h4>
                           <p className="text-xs text-text-disabled">
                             {new Date(oral.oralTestDate).toLocaleDateString('nb-NO')}
                           </p>
@@ -281,7 +281,7 @@ export default function StudentDashboardPage() {
                       <div className="mb-3">
                         <div className="h-2 bg-gray-200 rounded-full overflow-hidden">
                           <div
-                            className={`h-full ${oral.score >= 50 ? 'bg-purple-600' : oral.score >= 35 ? 'bg-purple-400' : 'bg-purple-300'}`}
+                            className={`h-full ${oral.score >= 50 ? 'bg-indigo-600' : oral.score >= 35 ? 'bg-indigo-400' : 'bg-indigo-300'}`}
                             style={{ width: `${(oral.score / oral.maxScore) * 100}%` }}
                           />
                         </div>

--- a/app/course/[courseId]/test/[testId]/analytics/page.tsx
+++ b/app/course/[courseId]/test/[testId]/analytics/page.tsx
@@ -132,7 +132,7 @@ export default function TestAnalyticsPage() {
         <div className="mb-6">
           <Link
             href={`/course/${courseId}/test/${testId}`}
-            className="inline-flex items-center gap-2 text-brand hover:text-rose-800 mb-2"
+            className="inline-flex items-center gap-2 text-brand hover:text-brand-hover mb-2"
           >
             <ArrowLeft size={20} />
             {t('test.backToTest')}
@@ -352,7 +352,7 @@ export default function TestAnalyticsPage() {
                             ta.labels.map(label => (
                               <span
                                 key={label}
-                                className="inline-block px-2 py-0.5 bg-violet-100 text-violet-700 rounded text-xs"
+                                className="inline-block px-2 py-0.5 bg-indigo-100 text-indigo-700 rounded text-xs"
                               >
                                 {label}
                               </span>

--- a/app/course/[courseId]/test/[testId]/page.tsx
+++ b/app/course/[courseId]/test/[testId]/page.tsx
@@ -509,7 +509,7 @@ export default function TestFeedbackPage() {
           <div>
             <Link
               href={`/course/${courseId}`}
-              className="inline-flex items-center gap-2 text-brand hover:text-rose-800 mb-2"
+              className="inline-flex items-center gap-2 text-brand hover:text-brand-hover mb-2"
             >
               <ArrowLeft size={20} />
               {t('test.backToCourse')}
@@ -536,7 +536,7 @@ export default function TestFeedbackPage() {
           <div className="flex gap-3">
             <Link
               href={`/course/${courseId}/test/${testId}/analytics`}
-              className="flex items-center gap-2 px-4 py-2 bg-violet-600 text-white rounded-lg hover:bg-violet-700 transition"
+              className="flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition"
               title={t('test.taskAnalyticsTitle')}
             >
               <BarChart3 size={18} />
@@ -554,7 +554,7 @@ export default function TestFeedbackPage() {
         </div>
 
         {/* Test Settings Section */}
-        <div className="bg-surface rounded-lg shadow-sm p-6 mb-8 border-2 border-violet-200">
+        <div className="bg-surface rounded-lg shadow-sm p-6 mb-8 border-2 border-indigo-200">
           <div className="flex items-center justify-between mb-6">
             <div>
               <h2 className="text-2xl font-display font-bold text-text-primary">{t('test.testSettings')}</h2>
@@ -703,7 +703,7 @@ export default function TestFeedbackPage() {
                           </div>
                           <Link
                             href={`/course/${courseId}/student/${student.id}`}
-                            className="p-1 text-brand hover:bg-violet-100 rounded transition"
+                            className="p-1 text-brand hover:bg-indigo-100 rounded transition"
                             title={t('test.viewStudentDashboard')}
                             onClick={(e) => e.stopPropagation()}
                           >
@@ -831,7 +831,7 @@ export default function TestFeedbackPage() {
                             return (
                               <div key={subtask.id} className={`ml-4 border rounded-lg p-4 transition-colors ${
                               activeSubtask?.taskId === task.id && activeSubtask?.subtaskId === subtask.id
-                                ? 'border-brand bg-violet-50 ring-2 ring-brand/30'
+                                ? 'border-brand bg-indigo-50 ring-2 ring-brand/30'
                                 : 'border-border bg-surface-alt'
                             }`}>
                                 <div className="flex items-center gap-4 mb-3">
@@ -849,7 +849,7 @@ export default function TestFeedbackPage() {
                                           className={`w-9 h-9 rounded-lg font-semibold transition-all ${
                                             feedback.points === p
                                               ? 'bg-brand text-white shadow-md scale-110'
-                                              : 'bg-surface border border-border text-text-secondary hover:bg-violet-50 hover:border-brand'
+                                              : 'bg-surface border border-border text-text-secondary hover:bg-indigo-50 hover:border-brand'
                                           }`}
                                         >
                                           {p}
@@ -884,7 +884,7 @@ export default function TestFeedbackPage() {
                       ) : (
                         <div className={`border rounded-lg p-4 transition-colors ${
                           activeSubtask?.taskId === task.id && !activeSubtask?.subtaskId
-                            ? 'border-brand bg-violet-50 ring-2 ring-brand/30'
+                            ? 'border-brand bg-indigo-50 ring-2 ring-brand/30'
                             : 'border-border bg-surface-alt'
                         }`}>
                           {(() => {
@@ -917,7 +917,7 @@ export default function TestFeedbackPage() {
                                           className={`w-9 h-9 rounded-lg font-semibold transition-all ${
                                             feedback.points === p
                                               ? 'bg-brand text-white shadow-md scale-110'
-                                              : 'bg-surface border border-border text-text-secondary hover:bg-violet-50 hover:border-brand'
+                                              : 'bg-surface border border-border text-text-secondary hover:bg-indigo-50 hover:border-brand'
                                           }`}
                                         >
                                           {p}

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -30,7 +30,7 @@ export default function HelpPage() {
         <div className="mb-6">
           <Link
             href="/courses"
-            className="inline-flex items-center gap-2 text-brand hover:text-rose-800 mb-4"
+            className="inline-flex items-center gap-2 text-brand hover:text-brand-hover mb-4"
           >
             <ArrowLeft size={20} />
             {t('common.back')}
@@ -46,7 +46,7 @@ export default function HelpPage() {
         <div className="bg-surface rounded-lg shadow-sm p-6 mb-6">
           <h2 className="text-xl font-bold text-text-primary mb-4">{t('help.quickLinks')}</h2>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-            <a href="#workflow" className="flex items-center gap-2 p-3 bg-violet-50 text-violet-700 rounded-lg hover:bg-violet-100 transition-colors">
+            <a href="#workflow" className="flex items-center gap-2 p-3 bg-indigo-50 text-indigo-700 rounded-lg hover:bg-indigo-100 transition-colors">
               <GraduationCap size={18} />
               <span className="text-sm font-medium">{t('help.workflow')}</span>
             </a>
@@ -89,7 +89,7 @@ export default function HelpPage() {
           </div>
 
           <div className="space-y-4">
-            <div className="border-l-4 border-violet-600 pl-4">
+            <div className="border-l-4 border-indigo-600 pl-4">
               <h3 className="font-semibold text-text-primary mb-2">1. {t('help.step1Title')}</h3>
               <p className="text-sm text-text-secondary">{t('help.step1Desc')}</p>
             </div>
@@ -231,7 +231,7 @@ export default function HelpPage() {
               <h3 className="font-semibold text-text-primary mb-3">{t('help.exportContents')}</h3>
 
               <div className="space-y-3 text-sm">
-                <div className="border-l-4 border-violet-600 pl-3">
+                <div className="border-l-4 border-indigo-600 pl-3">
                   <h4 className="font-semibold text-text-primary mb-1">{t('help.exportContent1Title')}</h4>
                   <p className="text-text-secondary">
                     {t('help.exportContent1Desc')}
@@ -273,9 +273,9 @@ export default function HelpPage() {
               </ul>
             </div>
 
-            <div className="bg-violet-50 border border-violet-200 rounded-lg p-4">
-              <h3 className="font-semibold text-violet-900 mb-2">{t('help.exportTipsTitle')}</h3>
-              <ul className="text-sm text-violet-800 space-y-1">
+            <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-4">
+              <h3 className="font-semibold text-indigo-900 mb-2">{t('help.exportTipsTitle')}</h3>
+              <ul className="text-sm text-indigo-800 space-y-1">
                 <li>• {t('help.exportTip1')}</li>
                 <li>• {t('help.exportTip2')}</li>
                 <li>• {t('help.exportTip3')}</li>
@@ -344,9 +344,9 @@ export default function HelpPage() {
               </div>
             </div>
 
-            <div className="bg-violet-50 border border-violet-200 rounded-lg p-4">
-              <h3 className="font-semibold text-violet-900 mb-2">{t('help.whyThisSystem')}</h3>
-              <ul className="text-sm text-violet-800 space-y-1">
+            <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-4">
+              <h3 className="font-semibold text-indigo-900 mb-2">{t('help.whyThisSystem')}</h3>
+              <ul className="text-sm text-indigo-800 space-y-1">
                 <li>• {t('help.benefit1')}</li>
                 <li>• {t('help.benefit2')}</li>
                 <li>• {t('help.benefit3')}</li>
@@ -437,9 +437,9 @@ export default function HelpPage() {
               <p className="text-sm text-text-secondary mb-2">{t('help.createSnippetsDesc')}</p>
             </div>
 
-            <div className="bg-violet-50 border border-violet-200 rounded-lg p-4">
-              <h3 className="font-semibold text-violet-900 mb-2">{t('help.standardSnippets')}</h3>
-              <div className="grid grid-cols-2 gap-2 text-sm text-violet-800">
+            <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-4">
+              <h3 className="font-semibold text-indigo-900 mb-2">{t('help.standardSnippets')}</h3>
+              <div className="grid grid-cols-2 gap-2 text-sm text-indigo-800">
                 <div>• {t('help.standardSnippet1')}</div>
                 <div>• {t('help.standardSnippet2')}</div>
                 <div>• {t('help.standardSnippet3')}</div>
@@ -502,7 +502,7 @@ export default function HelpPage() {
           </div>
 
           <div className="grid md:grid-cols-2 gap-4">
-            <div className="border-l-4 border-violet-600 pl-4">
+            <div className="border-l-4 border-indigo-600 pl-4">
               <h3 className="font-semibold text-text-primary mb-1">{t('help.tip1Title')}</h3>
               <p className="text-sm text-text-secondary">{t('help.tip1Desc')}</p>
             </div>
@@ -535,12 +535,12 @@ export default function HelpPage() {
         </div>
 
         {/* Footer */}
-        <div className="bg-violet-50 border border-violet-200 rounded-lg p-6 text-center">
-          <h3 className="font-semibold text-violet-900 mb-2">{t('help.needMoreHelp')}</h3>
-          <p className="text-sm text-violet-800 mb-4">{t('help.contactInfo')}</p>
+        <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-6 text-center">
+          <h3 className="font-semibold text-indigo-900 mb-2">{t('help.needMoreHelp')}</h3>
+          <p className="text-sm text-indigo-800 mb-4">{t('help.contactInfo')}</p>
 
-          <div className="flex items-center justify-center gap-4 pt-4 border-t border-violet-300">
-            <div className="flex items-center gap-2 text-violet-700">
+          <div className="flex items-center justify-center gap-4 pt-4 border-t border-indigo-300">
+            <div className="flex items-center gap-2 text-indigo-700">
               <User size={16} />
               <span className="text-sm">{t('help.author')}</span>
             </div>
@@ -548,7 +548,7 @@ export default function HelpPage() {
               href="https://github.com/lektorodd/tilbakemeldingsapp"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-2 text-violet-700 hover:text-violet-900 transition-colors"
+              className="flex items-center gap-2 text-indigo-700 hover:text-indigo-900 transition-colors"
             >
               <Github size={16} />
               <span className="text-sm">{t('help.viewOnGithub')}</span>

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -11,16 +11,23 @@ export default function Icon() {
     (
       <div
         style={{
-          fontSize: 26,
           width: '100%',
           height: '100%',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          background: 'transparent',
+          background: '#4F46E5',
+          borderRadius: 6,
         }}
       >
-        🎓
+        <div style={{
+          fontSize: 20,
+          fontWeight: 800,
+          color: 'white',
+          letterSpacing: '-0.05em',
+        }}>
+          M
+        </div>
       </div>
     ),
     {

--- a/components/FeedbackForm.tsx
+++ b/components/FeedbackForm.tsx
@@ -68,7 +68,7 @@ export default function FeedbackForm({ tasks, feedbacks, onFeedbackChange }: Fee
                                 className={`w-9 h-9 rounded-lg font-semibold transition-all ${
                                   feedback.points === p
                                     ? 'bg-brand text-white shadow-md scale-110'
-                                    : 'bg-surface border border-border text-text-secondary hover:bg-violet-50 hover:border-brand'
+                                    : 'bg-surface border border-border text-text-secondary hover:bg-indigo-50 hover:border-brand'
                                 }`}
                               >
                                 {p}
@@ -117,7 +117,7 @@ export default function FeedbackForm({ tasks, feedbacks, onFeedbackChange }: Fee
                                 className={`w-9 h-9 rounded-lg font-semibold transition-all ${
                                   feedback.points === p
                                     ? 'bg-brand text-white shadow-md scale-110'
-                                    : 'bg-surface border border-border text-text-secondary hover:bg-violet-50 hover:border-brand'
+                                    : 'bg-surface border border-border text-text-secondary hover:bg-indigo-50 hover:border-brand'
                                 }`}
                               >
                                 {p}

--- a/components/LabelManager.tsx
+++ b/components/LabelManager.tsx
@@ -59,7 +59,7 @@ export default function LabelManager({ labels, onLabelsChange }: LabelManagerPro
             value={newLabel}
             onChange={(e) => setNewLabel(e.target.value)}
             onKeyPress={(e) => e.key === 'Enter' && handleAddLabel()}
-            className="flex-1 px-3 py-1.5 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 text-sm text-text-primary"
+            className="flex-1 px-3 py-1.5 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm text-text-primary"
             placeholder={t('course.labelPlaceholder')}
             autoFocus
           />
@@ -88,12 +88,12 @@ export default function LabelManager({ labels, onLabelsChange }: LabelManagerPro
           labels.map(label => (
             <div
               key={label}
-              className="flex items-center gap-1 px-3 py-1 bg-purple-100 text-purple-800 rounded-full text-sm"
+              className="flex items-center gap-1 px-3 py-1 bg-indigo-100 text-indigo-800 rounded-full text-sm"
             >
               <span>{label}</span>
               <button
                 onClick={() => handleRemoveLabel(label)}
-                className="hover:bg-purple-200 rounded-full p-0.5 transition"
+                className="hover:bg-indigo-200 rounded-full p-0.5 transition"
               >
                 <X size={14} />
               </button>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import LanguageSelector from './LanguageSelector';
-import { Home, HelpCircle, Github } from 'lucide-react';
+import { GraduationCap, HelpCircle, Github } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
 
 export default function Navbar() {
@@ -22,7 +22,7 @@ export default function Navbar() {
               href="/courses"
               className="flex items-center gap-2 text-text-primary hover:text-brand transition-colors"
             >
-              <Home size={20} />
+              <GraduationCap size={20} />
               <span className="font-display font-semibold text-lg">{t('common.appName')}</span>
             </Link>
           </div>

--- a/components/OralFeedbackForm.tsx
+++ b/components/OralFeedbackForm.tsx
@@ -87,7 +87,7 @@ export default function OralFeedbackForm({
         <p className="text-sm text-text-secondary mt-1">{t('oral.subtitle')}</p>
 
         {/* Score Display */}
-        <div className="mt-4 p-4 bg-violet-50 border-2 border-violet-200 rounded-lg">
+        <div className="mt-4 p-4 bg-indigo-50 border-2 border-indigo-200 rounded-lg">
           <div className="flex items-center justify-between">
             <span className="font-semibold text-text-primary">{t('oral.calculatedScore')}:</span>
             <span className="text-3xl font-display font-bold text-brand">{score} / 60</span>
@@ -153,8 +153,8 @@ export default function OralFeedbackForm({
                           onClick={() => updateDimension(dimensionType, { points: p })}
                           className={`w-8 h-8 rounded-lg font-semibold text-sm transition-all ${
                             dimension.points === p
-                              ? 'bg-purple-600 text-white shadow-md scale-110'
-                              : 'bg-surface border border-border text-text-secondary hover:bg-purple-50 hover:border-purple-400'
+                              ? 'bg-indigo-600 text-white shadow-md scale-110'
+                              : 'bg-surface border border-border text-text-secondary hover:bg-indigo-50 hover:border-indigo-400'
                           }`}
                         >
                           {p}

--- a/components/OralTestListPanel.tsx
+++ b/components/OralTestListPanel.tsx
@@ -28,13 +28,13 @@ export default function OralTestListPanel({
     <div className="bg-surface rounded-lg shadow-sm p-6">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
-          <MessageSquare size={24} className="text-purple-600" />
+          <MessageSquare size={24} className="text-indigo-600" />
           <h2 className="text-2xl font-display font-bold text-text-primary">{t('course.oralTests')}</h2>
           <span className="text-text-secondary">({oralTests.length})</span>
         </div>
         <button
           onClick={onAddOralTest}
-          className="flex items-center gap-1 px-3 py-1 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors text-sm"
+          className="flex items-center gap-1 px-3 py-1 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors text-sm"
         >
           <Plus size={16} />
           {t('common.add')}
@@ -61,7 +61,7 @@ export default function OralTestListPanel({
                         <p className="text-xs text-text-secondary">{oralTest.description}</p>
                       )}
                       {oralTest.topics && oralTest.topics.length > 0 && (
-                        <p className="text-xs text-purple-600 mt-1">
+                        <p className="text-xs text-indigo-600 mt-1">
                           {t('course.topics')}: {oralTest.topics.join(', ')}
                         </p>
                       )}
@@ -79,7 +79,7 @@ export default function OralTestListPanel({
                     <div className="flex gap-1">
                       <button
                         onClick={() => onEditOralTest(oralTest)}
-                        className="p-1 text-purple-600 hover:bg-purple-50 rounded transition"
+                        className="p-1 text-indigo-600 hover:bg-indigo-50 rounded transition"
                       >
                         <Edit size={14} />
                       </button>
@@ -93,7 +93,7 @@ export default function OralTestListPanel({
                   </div>
                   <Link
                     href={`/course/${courseId}/oral/${oralTest.id}`}
-                    className="block text-center px-3 py-1 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors text-sm"
+                    className="block text-center px-3 py-1 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors text-sm"
                   >
                     <MessageSquare size={14} className="inline mr-1" />
                     {t('course.giveOralAssessment')}

--- a/components/RadarChart.tsx
+++ b/components/RadarChart.tsx
@@ -64,7 +64,7 @@ export default function RadarChart({ dimensions, width = 300, height = 250, maxV
           cy={centerY}
           r={(level / maxValue) * radius}
           fill="none"
-          stroke="#e5e7eb"
+          stroke="#E2E8F0"
           strokeWidth="1"
         />
       ))}
@@ -77,7 +77,7 @@ export default function RadarChart({ dimensions, width = 300, height = 250, maxV
           y1={axis.line.y1}
           x2={axis.line.x2}
           y2={axis.line.y2}
-          stroke="#d1d5db"
+          stroke="#CBD5E1"
           strokeWidth="1"
         />
       ))}
@@ -85,8 +85,8 @@ export default function RadarChart({ dimensions, width = 300, height = 250, maxV
       {/* Data polygon */}
       <polygon
         points={dataPolygon}
-        fill="rgba(147, 51, 234, 0.25)"
-        stroke="rgb(147, 51, 234)"
+        fill="rgba(79, 70, 229, 0.2)"
+        stroke="rgb(79, 70, 229)"
         strokeWidth="2"
       />
 
@@ -97,7 +97,7 @@ export default function RadarChart({ dimensions, width = 300, height = 250, maxV
           cx={point.x}
           cy={point.y}
           r="4"
-          fill="rgb(147, 51, 234)"
+          fill="rgb(79, 70, 229)"
         />
       ))}
 
@@ -131,7 +131,7 @@ export default function RadarChart({ dimensions, width = 300, height = 250, maxV
               textAnchor="middle"
               fontSize="11"
               fontWeight="bold"
-              fill="#7c3aed"
+              fill="#4F46E5"
               dominantBaseline="middle"
             >
               {axis.value}/6
@@ -141,12 +141,12 @@ export default function RadarChart({ dimensions, width = 300, height = 250, maxV
       })}
 
       {/* Center point */}
-      <circle cx={centerX} cy={centerY} r="2" fill="#9ca3af" />
+      <circle cx={centerX} cy={centerY} r="2" fill="#94A3B8" />
 
       {/* Grid level labels */}
-      <text x={centerX} y={centerY - (2 / maxValue) * radius} fontSize="8" fill="#9ca3af" textAnchor="middle" dy="-2">2</text>
-      <text x={centerX} y={centerY - (4 / maxValue) * radius} fontSize="8" fill="#9ca3af" textAnchor="middle" dy="-2">4</text>
-      <text x={centerX} y={centerY - (6 / maxValue) * radius} fontSize="8" fill="#9ca3af" textAnchor="middle" dy="-2">6</text>
+      <text x={centerX} y={centerY - (2 / maxValue) * radius} fontSize="8" fill="#94A3B8" textAnchor="middle" dy="-2">2</text>
+      <text x={centerX} y={centerY - (4 / maxValue) * radius} fontSize="8" fill="#94A3B8" textAnchor="middle" dy="-2">4</text>
+      <text x={centerX} y={centerY - (6 / maxValue) * radius} fontSize="8" fill="#94A3B8" textAnchor="middle" dy="-2">6</text>
     </svg>
   );
 }

--- a/components/SnippetPicker.tsx
+++ b/components/SnippetPicker.tsx
@@ -63,7 +63,7 @@ export default function SnippetPicker({
       case 'standard': return 'bg-stone-100 text-stone-700';
       case 'encouragement': return 'bg-emerald-100 text-emerald-700';
       case 'error': return 'bg-rose-100 text-brand-hover';
-      case 'custom': return 'bg-violet-100 text-violet-700';
+      case 'custom': return 'bg-indigo-100 text-indigo-700';
       default: return 'bg-stone-100 text-stone-700';
     }
   };
@@ -81,9 +81,9 @@ export default function SnippetPicker({
       </button>
 
       {isOpen && (
-        <div className="absolute z-50 mt-2 w-80 bg-surface rounded-lg shadow-xl border-2 border-violet-200 max-h-96 overflow-hidden flex flex-col">
+        <div className="absolute z-50 mt-2 w-80 bg-surface rounded-lg shadow-xl border-2 border-indigo-200 max-h-96 overflow-hidden flex flex-col">
           {/* Header */}
-          <div className="p-3 border-b border-border bg-violet-50">
+          <div className="p-3 border-b border-border bg-indigo-50">
             <div className="flex items-center justify-between mb-2">
               <h3 className="font-semibold text-text-primary flex items-center gap-2">
                 <BookmarkPlus size={18} className="text-brand" />
@@ -91,7 +91,7 @@ export default function SnippetPicker({
               </h3>
               <button
                 onClick={() => setIsOpen(false)}
-                className="p-1 hover:bg-violet-100 rounded transition"
+                className="p-1 hover:bg-indigo-100 rounded transition"
               >
                 <X size={16} />
               </button>
@@ -102,7 +102,7 @@ export default function SnippetPicker({
               <button
                 onClick={() => setFilter('all')}
                 className={`px-2 py-1 text-xs rounded transition-colors ${
-                  filter === 'all' ? 'bg-brand text-white' : 'bg-surface text-text-secondary hover:bg-violet-100'
+                  filter === 'all' ? 'bg-brand text-white' : 'bg-surface text-text-secondary hover:bg-indigo-100'
                 }`}
               >
                 Alle ({snippets.length})
@@ -184,7 +184,7 @@ export default function SnippetPicker({
                       if (e.key === 'Escape') setShowAddForm(false);
                     }}
                     placeholder="Skriv inn ny snøggtekst..."
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-violet-500 text-sm text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm text-text-primary"
                     autoFocus
                   />
                   <div className="flex gap-2">
@@ -208,7 +208,7 @@ export default function SnippetPicker({
               ) : (
                 <button
                   onClick={() => setShowAddForm(true)}
-                  className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-violet-100 text-violet-700 rounded-lg hover:bg-violet-200 transition-colors text-sm"
+                  className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-indigo-100 text-indigo-700 rounded-lg hover:bg-indigo-200 transition-colors text-sm"
                 >
                   <Plus size={16} />
                   Lag ny snøggtekst

--- a/components/SnippetSidebar.tsx
+++ b/components/SnippetSidebar.tsx
@@ -33,7 +33,7 @@ export default function SnippetSidebar({
       case 'standard': return 'bg-stone-100 text-stone-700';
       case 'encouragement': return 'bg-emerald-100 text-emerald-700';
       case 'error': return 'bg-rose-100 text-rose-700';
-      case 'custom': return 'bg-violet-100 text-violet-700';
+      case 'custom': return 'bg-indigo-100 text-indigo-700';
       default: return 'bg-stone-100 text-stone-700';
     }
   };
@@ -176,7 +176,7 @@ export default function SnippetSidebar({
             ) : (
               <button
                 onClick={() => setShowAddForm(true)}
-                className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-violet-100 text-violet-700 rounded-lg hover:bg-violet-200 transition-colors text-sm"
+                className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-indigo-100 text-indigo-700 rounded-lg hover:bg-indigo-200 transition-colors text-sm"
               >
                 <Plus size={16} />
                 {t('snippets.addNew') || 'Lag ny snøggtekst'}

--- a/components/TaskConfiguration.tsx
+++ b/components/TaskConfiguration.tsx
@@ -260,7 +260,7 @@ export default function TaskConfiguration({ tasks, onTasksChange, availableLabel
                         onClick={() => toggleTaskLabel(task.id, label)}
                         className={`px-2 py-0.5 rounded-full text-xs transition ${
                           task.labels.includes(label)
-                            ? 'bg-violet-600 text-white'
+                            ? 'bg-indigo-600 text-white'
                             : 'bg-surface text-text-secondary hover:bg-gray-300 border border-border'
                         }`}
                       >
@@ -329,7 +329,7 @@ export default function TaskConfiguration({ tasks, onTasksChange, availableLabel
                                 onClick={() => toggleSubtaskLabel(task.id, subtask.id, label)}
                                 className={`px-2 py-0.5 rounded-full text-xs transition ${
                                   subtask.labels.includes(label)
-                                    ? 'bg-violet-600 text-white'
+                                    ? 'bg-indigo-600 text-white'
                                     : 'bg-white text-text-secondary hover:bg-gray-200 border border-border'
                                 }`}
                               >
@@ -343,7 +343,7 @@ export default function TaskConfiguration({ tasks, onTasksChange, availableLabel
                   ))}
                   <button
                     onClick={() => addSubtask(task.id)}
-                    className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-brand hover:bg-violet-50 rounded-lg transition"
+                    className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-brand hover:bg-indigo-50 rounded-lg transition"
                   >
                     <Plus size={14} />
                     {t('test.addSubtaskButton')}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,32 +9,32 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        // Matte neutral palette
-        background: '#FAFAFA',
+        // Modern neutral palette (slate-tinted)
+        background: '#F8FAFC',
         surface: '#FFFFFF',
-        'surface-alt': '#F4F4F5',
+        'surface-alt': '#F1F5F9',
 
-        // Text colors
-        'text-primary': '#1A1A1A',
-        'text-secondary': '#4B5563',
-        'text-disabled': '#9CA3AF',
+        // Text colors (deeper, richer)
+        'text-primary': '#0F172A',
+        'text-secondary': '#475569',
+        'text-disabled': '#94A3B8',
 
-        // Brand (educational blue)
+        // Brand (indigo)
         brand: {
-          DEFAULT: '#2563EB',
-          hover: '#1D4ED8',
-          active: '#1E40AF',
+          DEFAULT: '#4F46E5',
+          hover: '#4338CA',
+          active: '#3730A3',
         },
 
-        // Semantic colors
-        success: '#10B981',
-        warning: '#F59E0B',
-        danger: '#EF4444',
-        focus: '#3B82F6',
+        // Semantic colors (refined)
+        success: '#059669',
+        warning: '#D97706',
+        danger: '#DC2626',
+        focus: '#6366F1',
       },
       borderColor: {
-        DEFAULT: '#E5E7EB',
-        border: '#E5E7EB',
+        DEFAULT: '#E2E8F0',
+        border: '#E2E8F0',
       },
       fontFamily: {
         sans: ['Inter', 'SF Pro Text', 'Segoe UI', 'Roboto', 'Helvetica', 'Arial', 'sans-serif'],

--- a/utils/typstExport.ts
+++ b/utils/typstExport.ts
@@ -212,7 +212,7 @@ export function generateTypstDocument(data: ExportData): string {
   inset: (x: 0.8em, y: 0.55em),
   stroke: 0.5pt + rgb("#E2E8F0"),
   align: (center, center, left),
-  fill: (_, row) => if row == 0 { rgb("#2563EB") } else if calc.even(row) { rgb("#F8FAFC") } else { white },
+  fill: (_, row) => if row == 0 { rgb("#4F46E5") } else if calc.even(row) { rgb("#F1F5F9") } else { white },
   table.header(
     [#text(fill: white, weight: "bold")[${t.task}]],
     [#text(fill: white, weight: "bold")[${t.points}]],
@@ -244,17 +244,17 @@ ${taskRows.join('\n')}
   margin: (x: 2cm, top: 1.8cm, bottom: 2cm),
   header: context {
     if counter(page).get().first() > 1 [
-      #text(size: 9pt, fill: rgb("#6B7280"))[${escapeTypst(testName)} #sym.dash.em ${escapeTypst(studentName)}]
+      #text(size: 9pt, fill: rgb("#64748B"))[${escapeTypst(testName)} #sym.dash.em ${escapeTypst(studentName)}]
       #h(1fr)
-      #text(size: 9pt, fill: rgb("#6B7280"))[${t.feedback}]
+      #text(size: 9pt, fill: rgb("#64748B"))[${t.feedback}]
       #v(0.3em)
-      #line(length: 100%, stroke: 0.3pt + rgb("#D1D5DB"))
+      #line(length: 100%, stroke: 0.3pt + rgb("#CBD5E1"))
     ]
   },
   footer: context {
     let total = counter(page).final().first()
     if total > 1 {
-      align(center, text(size: 9pt, fill: rgb("#9CA3AF"))[
+      align(center, text(size: 9pt, fill: rgb("#94A3B8"))[
         #counter(page).display("1 / 1", both: true)
       ])
     }
@@ -263,15 +263,15 @@ ${taskRows.join('\n')}
 #set text(
   size: 11pt,
   lang: "${t.lang}",
-  font: "Libertinus Sans",
+  font: "Source Sans 3",
 )
 #set par(justify: true)
-#show heading: set text(fill: rgb("#1E40AF"))
+#show heading: set text(fill: rgb("#3730A3"))
 #show link: underline
 
 #rect(
   width: 100%,
-  fill: rgb("#2563EB"),
+  fill: rgb("#4F46E5"),
   inset: (x: 1.5em, y: 1em),
   radius: 4pt,
 )[
@@ -286,7 +286,7 @@ ${taskRows.join('\n')}
 
 #rect(
   width: 100%,
-  fill: rgb("#F8FAFC"),
+  fill: rgb("#F1F5F9"),
   inset: (x: 1.2em, y: 0.8em),
   radius: 4pt,
   stroke: 0.5pt + rgb("#E2E8F0"),
@@ -340,7 +340,7 @@ export function generateOralTypstDocument(data: OralExportData): string {
   inset: (x: 0.8em, y: 0.55em),
   stroke: 0.5pt + rgb("#E2E8F0"),
   align: (left, center, left),
-  fill: (_, row) => if row == 0 { rgb("#2563EB") } else if calc.even(row) { rgb("#F8FAFC") } else { white },
+  fill: (_, row) => if row == 0 { rgb("#4F46E5") } else if calc.even(row) { rgb("#F1F5F9") } else { white },
   table.header(
     [#text(fill: white, weight: "bold")[${t.dimension}]],
     [#text(fill: white, weight: "bold")[${t.points}]],
@@ -372,17 +372,17 @@ ${dimensionRows}
   margin: (x: 2cm, top: 1.8cm, bottom: 2cm),
   header: context {
     if counter(page).get().first() > 1 [
-      #text(size: 9pt, fill: rgb("#6B7280"))[${escapeTypst(oralTestName)} #sym.dash.em ${escapeTypst(studentName)}]
+      #text(size: 9pt, fill: rgb("#64748B"))[${escapeTypst(oralTestName)} #sym.dash.em ${escapeTypst(studentName)}]
       #h(1fr)
-      #text(size: 9pt, fill: rgb("#6B7280"))[${t.oralAssessment}]
+      #text(size: 9pt, fill: rgb("#64748B"))[${t.oralAssessment}]
       #v(0.3em)
-      #line(length: 100%, stroke: 0.3pt + rgb("#D1D5DB"))
+      #line(length: 100%, stroke: 0.3pt + rgb("#CBD5E1"))
     ]
   },
   footer: context {
     let total = counter(page).final().first()
     if total > 1 {
-      align(center, text(size: 9pt, fill: rgb("#9CA3AF"))[
+      align(center, text(size: 9pt, fill: rgb("#94A3B8"))[
         #counter(page).display("1 / 1", both: true)
       ])
     }
@@ -391,15 +391,15 @@ ${dimensionRows}
 #set text(
   size: 11pt,
   lang: "${t.lang}",
-  font: "Libertinus Sans",
+  font: "Source Sans 3",
 )
 #set par(justify: true)
-#show heading: set text(fill: rgb("#1E40AF"))
+#show heading: set text(fill: rgb("#3730A3"))
 #show link: underline
 
 #rect(
   width: 100%,
-  fill: rgb("#2563EB"),
+  fill: rgb("#4F46E5"),
   inset: (x: 1.5em, y: 1em),
   radius: 4pt,
 )[
@@ -414,7 +414,7 @@ ${dimensionRows}
 
 #rect(
   width: 100%,
-  fill: rgb("#F8FAFC"),
+  fill: rgb("#F1F5F9"),
   inset: (x: 1.2em, y: 0.8em),
   radius: 4pt,
   stroke: 0.5pt + rgb("#E2E8F0"),


### PR DESCRIPTION
## Summary
This PR updates the application's color palette and design system from a blue-based theme to an indigo-based theme, along with refinements to the overall color tokens for better visual consistency and modern aesthetics.

## Key Changes

### Color Palette Updates
- **Primary Brand Color**: Changed from blue (`#2563EB`) to indigo (`#4F46E5`)
- **Brand Hover State**: Updated from `#1D4ED8` to `#4338CA`
- **Brand Active State**: Updated from `#1E40AF` to `#3730A3`
- **Accent Colors**: Replaced all violet/purple references with indigo throughout the UI
- **Neutral Palette**: Shifted from matte grays to slate-tinted neutrals for a more modern appearance
  - Background: `#FAFAFA` → `#F8FAFC`
  - Surface Alt: `#F4F4F5` → `#F1F5F9`
  - Text Primary: `#1A1A1A` → `#0F172A` (deeper)
  - Text Secondary: `#4B5563` → `#475569`
  - Text Disabled: `#9CA3AF` → `#94A3B8`

### Semantic Color Refinements
- Success: `#10B981` → `#059669`
- Warning: `#F59E0B` → `#D97706`
- Danger: `#EF4444` → `#DC2626`
- Focus: `#3B82F6` → `#6366F1`

### Component Updates
- Updated all UI components to use indigo instead of violet/purple
- Fixed hover states to use the new `brand-hover` token instead of hardcoded `rose-800`
- Updated quick links, cards, borders, and interactive elements throughout the help page, course pages, and analytics sections
- Updated radar chart colors to match the new indigo palette

### Icon Updates
- Replaced emoji-based app icons with a modern "M" monogram on indigo background
- Updated both favicon and Apple icon to use the new branding

### Typography & Export
- Changed default font in Typst exports from "Libertinus Sans" to "Source Sans 3"
- Updated all color references in PDF export templates to use new palette

### Files Modified
- `tailwind.config.ts` - Core color token definitions
- `app/help/page.tsx` - Help page styling
- `app/course/[courseId]/page.tsx` - Course detail page
- `app/course/[courseId]/analytics/page.tsx` - Analytics pages
- `app/course/[courseId]/test/[testId]/page.tsx` - Test feedback pages
- `app/course/[courseId]/oral/[oralTestId]/page.tsx` - Oral assessment pages
- `components/` - Various UI components (RadarChart, SnippetPicker, OralFeedbackForm, etc.)
- `utils/typstExport.ts` - PDF export color definitions
- `app/icon.tsx` & `app/apple-icon.tsx` - App icons

## Implementation Details
- All color changes maintain accessibility standards and contrast ratios
- The new indigo palette provides better visual hierarchy and modern aesthetics
- Consistent application across all interactive states (hover, active, focus)
- Updated design tokens ensure maintainability through centralized Tailwind configuration

https://claude.ai/code/session_01MLotcMWERsfbbmoHLxDiF7