### PR TITLE
Fix favicon: use graduation cap emoji on indigo background

### DIFF
--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -18,16 +18,10 @@ export default function AppleIcon() {
           justifyContent: 'center',
           background: '#4F46E5',
           borderRadius: 36,
+          fontSize: 120,
         }}
       >
-        <div style={{
-          fontSize: 110,
-          fontWeight: 800,
-          color: 'white',
-          letterSpacing: '-0.05em',
-        }}>
-          M
-        </div>
+        🎓
       </div>
     ),
     {

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -18,16 +18,10 @@ export default function Icon() {
           justifyContent: 'center',
           background: '#4F46E5',
           borderRadius: 6,
+          fontSize: 22,
         }}
       >
-        <div style={{
-          fontSize: 20,
-          fontWeight: 800,
-          color: 'white',
-          letterSpacing: '-0.05em',
-        }}>
-          M
-        </div>
+        🎓
       </div>
     ),
     {


### PR DESCRIPTION
The text-based "M" lettermark failed to render because ImageResponse (Satori) needs font data which may not be available without network. Revert to emoji rendering on the new indigo branded background.

https://claude.ai/code/session_01MLotcMWERsfbbmoHLxDiF7