### PR TITLE
Implement brand style guide: teal/coral palette, new typography

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -82,14 +82,14 @@ export default function AnalyticsPage() {
             <div className="bg-white rounded-lg shadow-md p-6">
               <div className="flex items-center justify-between mb-6">
                 <div className="flex items-center gap-3">
-                  <BarChart3 size={28} className="text-indigo-600" />
+                  <BarChart3 size={28} className="text-primary-600" />
                   <h2 className="text-2xl font-display font-bold text-gray-800">Task Difficulty Analysis</h2>
                 </div>
                 <div>
                   <select
                     value={selectedTest}
                     onChange={(e) => setSelectedTest(e.target.value)}
-                    className="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                    className="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
                   >
                     <option value="">All Tests</option>
                     {testNames.map(name => (
@@ -220,9 +220,9 @@ export default function AnalyticsPage() {
                         {studentData.averageScore.toFixed(1)}%
                       </p>
                     </div>
-                    <div className="bg-indigo-50 rounded-lg p-4 border border-indigo-200">
-                      <h3 className="text-sm font-medium text-indigo-800 mb-1">Latest Score</h3>
-                      <p className="text-3xl font-display font-bold text-indigo-600">
+                    <div className="bg-primary-50 rounded-lg p-4 border border-primary-200">
+                      <h3 className="text-sm font-medium text-primary-800 mb-1">Latest Score</h3>
+                      <p className="text-3xl font-display font-bold text-primary-600">
                         {studentData.feedbacks.length > 0
                           ? ((studentData.feedbacks[studentData.feedbacks.length - 1].totalPoints /
                               studentData.feedbacks[studentData.feedbacks.length - 1].maxPoints) *

--- a/app/course/[courseId]/analytics/page.tsx
+++ b/app/course/[courseId]/analytics/page.tsx
@@ -101,10 +101,10 @@ export default function CourseAnalyticsPage() {
           {course.oralTests && course.oralTests.length > 0 && (
             <div className="bg-surface rounded-lg shadow-sm p-4">
               <div className="flex items-center gap-2 mb-2">
-                <UserCircle size={20} className="text-indigo-600" />
+                <UserCircle size={20} className="text-primary-600" />
                 <h3 className="font-semibold text-text-primary">{t('course.oralTests')}</h3>
               </div>
-              <p className="text-3xl font-display font-bold text-indigo-600">{course.oralTests.length}</p>
+              <p className="text-3xl font-display font-bold text-primary-600">{course.oralTests.length}</p>
             </div>
           )}
         </div>
@@ -113,7 +113,7 @@ export default function CourseAnalyticsPage() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
           {/* Test Analytics Links */}
           {course.tests.length > 0 && (
-            <div className="bg-surface rounded-lg shadow-sm p-6 border-2 border-indigo-200">
+            <div className="bg-surface rounded-lg shadow-sm p-6 border-2 border-primary-200">
               <div className="flex items-center gap-2 mb-4">
                 <FileText size={24} className="text-brand" />
                 <h2 className="text-xl font-display font-bold text-text-primary">{t('test.taskAnalyticsTitle')}</h2>
@@ -128,7 +128,7 @@ export default function CourseAnalyticsPage() {
                       <Link
                         key={test.id}
                         href={`/course/${courseId}/test/${test.id}/analytics`}
-                        className="block p-3 border border-border rounded-lg hover:border-brand hover:bg-indigo-50 transition-all group"
+                        className="block p-3 border border-border rounded-lg hover:border-brand hover:bg-primary-50 transition-all group"
                       >
                         <div className="flex items-center justify-between">
                           <div className="flex-1">
@@ -208,8 +208,8 @@ export default function CourseAnalyticsPage() {
                       key={lp.label}
                       className={`p-3 rounded-lg border-2 transition-colors cursor-pointer ${
                         selectedLabel === lp.label
-                          ? 'border-indigo-600 bg-indigo-50'
-                          : 'border-border hover:border-indigo-300'
+                          ? 'border-primary-600 bg-primary-50'
+                          : 'border-border hover:border-primary-300'
                       }`}
                       onClick={() => setSelectedLabel(lp.label === selectedLabel ? null : lp.label)}
                     >
@@ -375,9 +375,9 @@ export default function CourseAnalyticsPage() {
         )}
 
         {/* Help Section */}
-        <div className="mt-6 bg-indigo-50 border border-indigo-200 rounded-lg p-4">
-          <h3 className="font-semibold text-indigo-900 mb-2">{t('analytics.howToUseAnalytics')}</h3>
-          <ul className="text-sm text-indigo-800 space-y-1">
+        <div className="mt-6 bg-primary-50 border border-primary-200 rounded-lg p-4">
+          <h3 className="font-semibold text-primary-900 mb-2">{t('analytics.howToUseAnalytics')}</h3>
+          <ul className="text-sm text-primary-800 space-y-1">
             <li>• {t('analytics.analyticsHelp1')}</li>
             <li>• {t('analytics.analyticsHelp2')}</li>
             <li>• {t('analytics.analyticsHelp3')}</li>

--- a/app/course/[courseId]/oral/[oralTestId]/page.tsx
+++ b/app/course/[courseId]/oral/[oralTestId]/page.tsx
@@ -196,13 +196,13 @@ export default function OralAssessmentPage() {
           <div>
             <Link
               href={`/course/${courseId}`}
-              className="inline-flex items-center gap-2 text-indigo-600 hover:text-indigo-800 mb-2"
+              className="inline-flex items-center gap-2 text-primary-600 hover:text-primary-800 mb-2"
             >
               <ArrowLeft size={20} />
               {t('test.backToCourse')}
             </Link>
             <div className="flex items-center gap-3">
-              <MessageSquare size={28} className="text-indigo-600" />
+              <MessageSquare size={28} className="text-primary-600" />
               <div>
                 <div className="flex items-center gap-4">
                   <h1 className="text-3xl font-display font-bold text-text-primary">{oralTest.name}</h1>
@@ -210,7 +210,7 @@ export default function OralAssessmentPage() {
                     <select
                       value={oralTestId}
                       onChange={(e) => router.push(`/course/${courseId}/oral/${e.target.value}`)}
-                      className="px-3 py-2 border border-border rounded-lg bg-surface text-text-primary hover:border-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-600 transition-all cursor-pointer"
+                      className="px-3 py-2 border border-border rounded-lg bg-surface text-text-primary hover:border-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-600 transition-all cursor-pointer"
                     >
                       {course.oralTests.map(ot => (
                         <option key={ot.id} value={ot.id}>
@@ -222,7 +222,7 @@ export default function OralAssessmentPage() {
                 </div>
                 {oralTest.description && <p className="text-text-secondary">{oralTest.description}</p>}
                 {oralTest.topics && oralTest.topics.length > 0 && (
-                  <p className="text-sm text-indigo-600 mt-1">
+                  <p className="text-sm text-primary-600 mt-1">
                     {t('course.topics')}: {oralTest.topics.join(', ')}
                   </p>
                 )}
@@ -260,8 +260,8 @@ export default function OralAssessmentPage() {
                         onClick={() => setSelectedStudent(student)}
                         className={`w-full text-left p-3 rounded-lg border transition-all ${
                           isSelected
-                            ? 'bg-indigo-100 border-indigo-500 shadow-md'
-                            : 'bg-background border-border hover:border-indigo-300 hover:bg-indigo-50'
+                            ? 'bg-primary-100 border-primary-500 shadow-md'
+                            : 'bg-background border-border hover:border-primary-300 hover:bg-primary-50'
                         }`}
                       >
                         <div className="flex items-center justify-between mb-1">
@@ -288,7 +288,7 @@ export default function OralAssessmentPage() {
 
               <Link
                 href={`/course/${courseId}/analytics`}
-                className="mt-4 flex items-center justify-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition w-full text-sm"
+                className="mt-4 flex items-center justify-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition w-full text-sm"
               >
                 <BarChart3 size={16} />
                 {t('course.viewAnalytics')}
@@ -300,7 +300,7 @@ export default function OralAssessmentPage() {
           <div className="lg:col-span-9">
             {!selectedStudent ? (
               <div className="bg-surface rounded-lg shadow-sm p-12 text-center">
-                <MessageSquare size={48} className="mx-auto text-indigo-300 mb-4" />
+                <MessageSquare size={48} className="mx-auto text-primary-300 mb-4" />
                 <p className="text-text-secondary text-lg">{t('test.selectStudentPrompt')}</p>
               </div>
             ) : (
@@ -313,7 +313,7 @@ export default function OralAssessmentPage() {
                     <button
                       onClick={handleSave}
                       disabled={isSaving}
-                      className="flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition disabled:opacity-50"
+                      className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition disabled:opacity-50"
                     >
                       <Save size={18} />
                       {t('common.save')}

--- a/app/course/[courseId]/page.tsx
+++ b/app/course/[courseId]/page.tsx
@@ -492,7 +492,7 @@ export default function CourseDetailPage() {
               </div>
               <div>
                 <p className="text-text-secondary">{t('course.possibleFeedback')}</p>
-                <p className="text-2xl font-display font-bold text-indigo-700">
+                <p className="text-2xl font-display font-bold text-primary-700">
                   {course.students.length * course.tests.length}
                 </p>
               </div>
@@ -580,7 +580,7 @@ export default function CourseDetailPage() {
                     value={bulkStudentText}
                     onChange={(e) => setBulkStudentText(e.target.value)}
                     rows={10}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary font-mono text-sm"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 text-text-primary font-mono text-sm"
                     placeholder={t('course.bulkAddPlaceholder')}
                     autoFocus
                   />
@@ -794,7 +794,7 @@ export default function CourseDetailPage() {
                     type="text"
                     value={newOralTestName}
                     onChange={(e) => setNewOralTestName(e.target.value)}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 text-text-primary"
                     placeholder={t('course.oralTestNamePlaceholder')}
                     autoFocus
                   />
@@ -808,7 +808,7 @@ export default function CourseDetailPage() {
                     type="text"
                     value={newOralTestDescription}
                     onChange={(e) => setNewOralTestDescription(e.target.value)}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 text-text-primary"
                     placeholder={t('course.oralTestDescriptionPlaceholder')}
                   />
                 </div>
@@ -821,7 +821,7 @@ export default function CourseDetailPage() {
                     type="date"
                     value={newOralTestDate}
                     onChange={(e) => setNewOralTestDate(e.target.value)}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 text-text-primary"
                   />
                 </div>
 
@@ -833,7 +833,7 @@ export default function CourseDetailPage() {
                     type="text"
                     value={newOralTestTopics}
                     onChange={(e) => setNewOralTestTopics(e.target.value)}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 text-text-primary"
                     placeholder={t('course.oralTestTopicsPlaceholder')}
                   />
                   <p className="text-xs text-text-disabled mt-1">
@@ -861,8 +861,8 @@ export default function CourseDetailPage() {
                           }}
                           className={`px-3 py-1 rounded-full text-sm transition ${
                             newOralTestLabels.includes(label)
-                              ? 'bg-indigo-600 text-white'
-                              : 'bg-indigo-100 text-indigo-800 hover:bg-indigo-200'
+                              ? 'bg-primary-600 text-white'
+                              : 'bg-primary-100 text-primary-800 hover:bg-primary-200'
                           }`}
                         >
                           {label}
@@ -889,7 +889,7 @@ export default function CourseDetailPage() {
                 </button>
                 <button
                   onClick={handleAddOralTest}
-                  className="flex-1 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition"
+                  className="flex-1 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition"
                 >
                   {t('course.addOralTestButton')}
                 </button>
@@ -1032,7 +1032,7 @@ export default function CourseDetailPage() {
                     type="text"
                     value={newOralTestName}
                     onChange={(e) => setNewOralTestName(e.target.value)}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 text-text-primary"
                     autoFocus
                   />
                 </div>
@@ -1045,7 +1045,7 @@ export default function CourseDetailPage() {
                     type="text"
                     value={newOralTestDescription}
                     onChange={(e) => setNewOralTestDescription(e.target.value)}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 text-text-primary"
                     placeholder={t('course.oralTestDescriptionPlaceholder')}
                   />
                 </div>
@@ -1058,7 +1058,7 @@ export default function CourseDetailPage() {
                     type="date"
                     value={newOralTestDate}
                     onChange={(e) => setNewOralTestDate(e.target.value)}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 text-text-primary"
                   />
                 </div>
 
@@ -1070,7 +1070,7 @@ export default function CourseDetailPage() {
                     type="text"
                     value={newOralTestTopics}
                     onChange={(e) => setNewOralTestTopics(e.target.value)}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 text-text-primary"
                     placeholder={t('course.oralTestTopicsPlaceholder')}
                   />
                   <p className="text-xs text-text-disabled mt-1">
@@ -1098,8 +1098,8 @@ export default function CourseDetailPage() {
                           }}
                           className={`px-3 py-1 rounded-full text-sm transition ${
                             newOralTestLabels.includes(label)
-                              ? 'bg-indigo-600 text-white'
-                              : 'bg-indigo-100 text-indigo-800 hover:bg-indigo-200'
+                              ? 'bg-primary-600 text-white'
+                              : 'bg-primary-100 text-primary-800 hover:bg-primary-200'
                           }`}
                         >
                           {label}
@@ -1122,7 +1122,7 @@ export default function CourseDetailPage() {
                 </button>
                 <button
                   onClick={handleUpdateOralTest}
-                  className="flex-1 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition"
+                  className="flex-1 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition"
                 >
                   {t('common.save')}
                 </button>

--- a/app/course/[courseId]/student/[studentId]/page.tsx
+++ b/app/course/[courseId]/student/[studentId]/page.tsx
@@ -243,7 +243,7 @@ export default function StudentDashboardPage() {
         {/* Oral Assessments Performance */}
         <div className="bg-surface rounded-lg shadow-sm p-6 mb-6">
           <div className="flex items-center gap-2 mb-4">
-            <MessageSquare size={24} className="text-indigo-600" />
+            <MessageSquare size={24} className="text-primary-600" />
             <h2 className="text-2xl font-display font-bold text-text-primary">{t('course.oralTests')}</h2>
           </div>
 
@@ -256,11 +256,11 @@ export default function StudentDashboardPage() {
                     {/* Oral test card - 50% width */}
                     <Link
                       href={`/course/${courseId}/oral/${oral.oralTestId}?student=${studentId}`}
-                      className="flex-[0.50] border border-border rounded-lg p-4 hover:border-indigo-500 hover:shadow-sm transition-colors cursor-pointer"
+                      className="flex-[0.50] border border-border rounded-lg p-4 hover:border-primary-500 hover:shadow-sm transition-colors cursor-pointer"
                     >
                       <div className="flex items-center justify-between mb-2">
                         <div>
-                          <h4 className="font-semibold text-text-primary hover:text-indigo-600 transition-colors">{oral.oralTestName}</h4>
+                          <h4 className="font-semibold text-text-primary hover:text-primary-600 transition-colors">{oral.oralTestName}</h4>
                           <p className="text-xs text-text-disabled">
                             {new Date(oral.oralTestDate).toLocaleDateString('nb-NO')}
                           </p>
@@ -281,7 +281,7 @@ export default function StudentDashboardPage() {
                       <div className="mb-3">
                         <div className="h-2 bg-gray-200 rounded-full overflow-hidden">
                           <div
-                            className={`h-full ${oral.score >= 50 ? 'bg-indigo-600' : oral.score >= 35 ? 'bg-indigo-400' : 'bg-indigo-300'}`}
+                            className={`h-full ${oral.score >= 50 ? 'bg-primary-600' : oral.score >= 35 ? 'bg-primary-400' : 'bg-primary-300'}`}
                             style={{ width: `${(oral.score / oral.maxScore) * 100}%` }}
                           />
                         </div>
@@ -421,7 +421,7 @@ export default function StudentDashboardPage() {
         {partPerformance && partPerformance.length > 0 && (
           <div className="bg-surface rounded-lg shadow-sm p-6 mb-6">
             <div className="flex items-center gap-2 mb-4">
-              <BookOpen size={24} className="text-indigo-600" />
+              <BookOpen size={24} className="text-primary-600" />
               <h2 className="text-2xl font-display font-bold text-text-primary">{t('dashboard.performanceByPart')}</h2>
             </div>
 
@@ -462,8 +462,8 @@ export default function StudentDashboardPage() {
 
             {/* Comparison insight */}
             {partPerformance.length === 2 && (
-              <div className="mt-4 p-4 bg-indigo-50 border border-indigo-200 rounded-lg">
-                <p className="text-sm text-indigo-900">
+              <div className="mt-4 p-4 bg-primary-50 border border-primary-200 rounded-lg">
+                <p className="text-sm text-primary-900">
                   <strong>{t('dashboard.comparison')}:</strong>{' '}
                   {partPerformance[0].averageScore > partPerformance[1].averageScore ? (
                     t('dashboard.betterNoAids')

--- a/app/course/[courseId]/test/[testId]/analytics/page.tsx
+++ b/app/course/[courseId]/test/[testId]/analytics/page.tsx
@@ -352,7 +352,7 @@ export default function TestAnalyticsPage() {
                             ta.labels.map(label => (
                               <span
                                 key={label}
-                                className="inline-block px-2 py-0.5 bg-indigo-100 text-indigo-700 rounded text-xs"
+                                className="inline-block px-2 py-0.5 bg-primary-100 text-primary-700 rounded text-xs"
                               >
                                 {label}
                               </span>

--- a/app/course/[courseId]/test/[testId]/page.tsx
+++ b/app/course/[courseId]/test/[testId]/page.tsx
@@ -536,7 +536,7 @@ export default function TestFeedbackPage() {
           <div className="flex gap-3">
             <Link
               href={`/course/${courseId}/test/${testId}/analytics`}
-              className="flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition"
+              className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition"
               title={t('test.taskAnalyticsTitle')}
             >
               <BarChart3 size={18} />
@@ -554,7 +554,7 @@ export default function TestFeedbackPage() {
         </div>
 
         {/* Test Settings Section */}
-        <div className="bg-surface rounded-lg shadow-sm p-6 mb-8 border-2 border-indigo-200">
+        <div className="bg-surface rounded-lg shadow-sm p-6 mb-8 border-2 border-primary-200">
           <div className="flex items-center justify-between mb-6">
             <div>
               <h2 className="text-2xl font-display font-bold text-text-primary">{t('test.testSettings')}</h2>
@@ -703,7 +703,7 @@ export default function TestFeedbackPage() {
                           </div>
                           <Link
                             href={`/course/${courseId}/student/${student.id}`}
-                            className="p-1 text-brand hover:bg-indigo-100 rounded transition"
+                            className="p-1 text-brand hover:bg-primary-100 rounded transition"
                             title={t('test.viewStudentDashboard')}
                             onClick={(e) => e.stopPropagation()}
                           >
@@ -831,7 +831,7 @@ export default function TestFeedbackPage() {
                             return (
                               <div key={subtask.id} className={`ml-4 border rounded-lg p-4 transition-colors ${
                               activeSubtask?.taskId === task.id && activeSubtask?.subtaskId === subtask.id
-                                ? 'border-brand bg-indigo-50 ring-2 ring-brand/30'
+                                ? 'border-brand bg-primary-50 ring-2 ring-brand/30'
                                 : 'border-border bg-surface-alt'
                             }`}>
                                 <div className="flex items-center gap-4 mb-3">
@@ -849,7 +849,7 @@ export default function TestFeedbackPage() {
                                           className={`w-9 h-9 rounded-lg font-semibold transition-all ${
                                             feedback.points === p
                                               ? 'bg-brand text-white shadow-md scale-110'
-                                              : 'bg-surface border border-border text-text-secondary hover:bg-indigo-50 hover:border-brand'
+                                              : 'bg-surface border border-border text-text-secondary hover:bg-primary-50 hover:border-brand'
                                           }`}
                                         >
                                           {p}
@@ -884,7 +884,7 @@ export default function TestFeedbackPage() {
                       ) : (
                         <div className={`border rounded-lg p-4 transition-colors ${
                           activeSubtask?.taskId === task.id && !activeSubtask?.subtaskId
-                            ? 'border-brand bg-indigo-50 ring-2 ring-brand/30'
+                            ? 'border-brand bg-primary-50 ring-2 ring-brand/30'
                             : 'border-border bg-surface-alt'
                         }`}>
                           {(() => {
@@ -917,7 +917,7 @@ export default function TestFeedbackPage() {
                                           className={`w-9 h-9 rounded-lg font-semibold transition-all ${
                                             feedback.points === p
                                               ? 'bg-brand text-white shadow-md scale-110'
-                                              : 'bg-surface border border-border text-text-secondary hover:bg-indigo-50 hover:border-brand'
+                                              : 'bg-surface border border-border text-text-secondary hover:bg-primary-50 hover:border-brand'
                                           }`}
                                         >
                                           {p}

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -467,7 +467,7 @@ export default function CoursesPage() {
             </label>
             <button
               onClick={handleFolderImport}
-              className="flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors shadow-sm"
+              className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors shadow-sm"
             >
               <FolderInput size={18} />
               {t('backup.importFolder')}

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,8 +3,9 @@
 @tailwind utilities;
 
 :root {
-  --font-inter: 'Inter', 'SF Pro Text', 'Segoe UI', 'Roboto', 'Helvetica', 'Arial', sans-serif;
-  --font-satoshi: 'Satoshi', 'Inter', sans-serif;
+  --font-source-sans: 'Source Sans 3', 'Source Sans Pro', system-ui, sans-serif;
+  --font-roboto-slab: 'Roboto Slab', Georgia, serif;
+  --font-jetbrains-mono: 'JetBrains Mono', 'Fira Code', monospace;
 }
 
 @layer base {
@@ -15,6 +16,14 @@
 
   h1, h2, h3, h4, h5, h6 {
     @apply font-display font-semibold text-text-primary;
+  }
+
+  code, pre, kbd, samp {
+    @apply font-mono;
+  }
+
+  a {
+    @apply text-link hover:text-link-hover;
   }
 }
 

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -46,7 +46,7 @@ export default function HelpPage() {
         <div className="bg-surface rounded-lg shadow-sm p-6 mb-6">
           <h2 className="text-xl font-bold text-text-primary mb-4">{t('help.quickLinks')}</h2>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-            <a href="#workflow" className="flex items-center gap-2 p-3 bg-indigo-50 text-indigo-700 rounded-lg hover:bg-indigo-100 transition-colors">
+            <a href="#workflow" className="flex items-center gap-2 p-3 bg-primary-50 text-primary-700 rounded-lg hover:bg-primary-100 transition-colors">
               <GraduationCap size={18} />
               <span className="text-sm font-medium">{t('help.workflow')}</span>
             </a>
@@ -89,7 +89,7 @@ export default function HelpPage() {
           </div>
 
           <div className="space-y-4">
-            <div className="border-l-4 border-indigo-600 pl-4">
+            <div className="border-l-4 border-primary-600 pl-4">
               <h3 className="font-semibold text-text-primary mb-2">1. {t('help.step1Title')}</h3>
               <p className="text-sm text-text-secondary">{t('help.step1Desc')}</p>
             </div>
@@ -231,7 +231,7 @@ export default function HelpPage() {
               <h3 className="font-semibold text-text-primary mb-3">{t('help.exportContents')}</h3>
 
               <div className="space-y-3 text-sm">
-                <div className="border-l-4 border-indigo-600 pl-3">
+                <div className="border-l-4 border-primary-600 pl-3">
                   <h4 className="font-semibold text-text-primary mb-1">{t('help.exportContent1Title')}</h4>
                   <p className="text-text-secondary">
                     {t('help.exportContent1Desc')}
@@ -273,9 +273,9 @@ export default function HelpPage() {
               </ul>
             </div>
 
-            <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-4">
-              <h3 className="font-semibold text-indigo-900 mb-2">{t('help.exportTipsTitle')}</h3>
-              <ul className="text-sm text-indigo-800 space-y-1">
+            <div className="bg-primary-50 border border-primary-200 rounded-lg p-4">
+              <h3 className="font-semibold text-primary-900 mb-2">{t('help.exportTipsTitle')}</h3>
+              <ul className="text-sm text-primary-800 space-y-1">
                 <li>• {t('help.exportTip1')}</li>
                 <li>• {t('help.exportTip2')}</li>
                 <li>• {t('help.exportTip3')}</li>
@@ -344,9 +344,9 @@ export default function HelpPage() {
               </div>
             </div>
 
-            <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-4">
-              <h3 className="font-semibold text-indigo-900 mb-2">{t('help.whyThisSystem')}</h3>
-              <ul className="text-sm text-indigo-800 space-y-1">
+            <div className="bg-primary-50 border border-primary-200 rounded-lg p-4">
+              <h3 className="font-semibold text-primary-900 mb-2">{t('help.whyThisSystem')}</h3>
+              <ul className="text-sm text-primary-800 space-y-1">
                 <li>• {t('help.benefit1')}</li>
                 <li>• {t('help.benefit2')}</li>
                 <li>• {t('help.benefit3')}</li>
@@ -437,9 +437,9 @@ export default function HelpPage() {
               <p className="text-sm text-text-secondary mb-2">{t('help.createSnippetsDesc')}</p>
             </div>
 
-            <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-4">
-              <h3 className="font-semibold text-indigo-900 mb-2">{t('help.standardSnippets')}</h3>
-              <div className="grid grid-cols-2 gap-2 text-sm text-indigo-800">
+            <div className="bg-primary-50 border border-primary-200 rounded-lg p-4">
+              <h3 className="font-semibold text-primary-900 mb-2">{t('help.standardSnippets')}</h3>
+              <div className="grid grid-cols-2 gap-2 text-sm text-primary-800">
                 <div>• {t('help.standardSnippet1')}</div>
                 <div>• {t('help.standardSnippet2')}</div>
                 <div>• {t('help.standardSnippet3')}</div>
@@ -502,7 +502,7 @@ export default function HelpPage() {
           </div>
 
           <div className="grid md:grid-cols-2 gap-4">
-            <div className="border-l-4 border-indigo-600 pl-4">
+            <div className="border-l-4 border-primary-600 pl-4">
               <h3 className="font-semibold text-text-primary mb-1">{t('help.tip1Title')}</h3>
               <p className="text-sm text-text-secondary">{t('help.tip1Desc')}</p>
             </div>
@@ -535,12 +535,12 @@ export default function HelpPage() {
         </div>
 
         {/* Footer */}
-        <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-6 text-center">
-          <h3 className="font-semibold text-indigo-900 mb-2">{t('help.needMoreHelp')}</h3>
-          <p className="text-sm text-indigo-800 mb-4">{t('help.contactInfo')}</p>
+        <div className="bg-primary-50 border border-primary-200 rounded-lg p-6 text-center">
+          <h3 className="font-semibold text-primary-900 mb-2">{t('help.needMoreHelp')}</h3>
+          <p className="text-sm text-primary-800 mb-4">{t('help.contactInfo')}</p>
 
-          <div className="flex items-center justify-center gap-4 pt-4 border-t border-indigo-300">
-            <div className="flex items-center gap-2 text-indigo-700">
+          <div className="flex items-center justify-center gap-4 pt-4 border-t border-primary-300">
+            <div className="flex items-center gap-2 text-primary-700">
               <User size={16} />
               <span className="text-sm">{t('help.author')}</span>
             </div>
@@ -548,7 +548,7 @@ export default function HelpPage() {
               href="https://github.com/lektorodd/tilbakemeldingsapp"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-2 text-indigo-700 hover:text-indigo-900 transition-colors"
+              className="flex items-center gap-2 text-primary-700 hover:text-primary-900 transition-colors"
             >
               <Github size={16} />
               <span className="text-sm">{t('help.viewOnGithub')}</span>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,6 @@
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
 import './globals.css'
 import ClientLayout from '@/components/ClientLayout'
-
-const inter = Inter({
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-inter',
-})
 
 export const metadata: Metadata = {
   title: 'MathMonitor',
@@ -20,10 +13,12 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className={inter.variable}>
+    <html lang="en">
       <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
-          href="https://api.fontshare.com/v2/css?f[]=satoshi@900,700,500,400&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,400;1,600&family=Roboto+Slab:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
           rel="stylesheet"
         />
       </head>

--- a/components/FeedbackForm.tsx
+++ b/components/FeedbackForm.tsx
@@ -68,7 +68,7 @@ export default function FeedbackForm({ tasks, feedbacks, onFeedbackChange }: Fee
                                 className={`w-9 h-9 rounded-lg font-semibold transition-all ${
                                   feedback.points === p
                                     ? 'bg-brand text-white shadow-md scale-110'
-                                    : 'bg-surface border border-border text-text-secondary hover:bg-indigo-50 hover:border-brand'
+                                    : 'bg-surface border border-border text-text-secondary hover:bg-primary-50 hover:border-brand'
                                 }`}
                               >
                                 {p}
@@ -117,7 +117,7 @@ export default function FeedbackForm({ tasks, feedbacks, onFeedbackChange }: Fee
                                 className={`w-9 h-9 rounded-lg font-semibold transition-all ${
                                   feedback.points === p
                                     ? 'bg-brand text-white shadow-md scale-110'
-                                    : 'bg-surface border border-border text-text-secondary hover:bg-indigo-50 hover:border-brand'
+                                    : 'bg-surface border border-border text-text-secondary hover:bg-primary-50 hover:border-brand'
                                 }`}
                               >
                                 {p}

--- a/components/LabelManager.tsx
+++ b/components/LabelManager.tsx
@@ -59,7 +59,7 @@ export default function LabelManager({ labels, onLabelsChange }: LabelManagerPro
             value={newLabel}
             onChange={(e) => setNewLabel(e.target.value)}
             onKeyPress={(e) => e.key === 'Enter' && handleAddLabel()}
-            className="flex-1 px-3 py-1.5 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm text-text-primary"
+            className="flex-1 px-3 py-1.5 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 text-sm text-text-primary"
             placeholder={t('course.labelPlaceholder')}
             autoFocus
           />
@@ -88,12 +88,12 @@ export default function LabelManager({ labels, onLabelsChange }: LabelManagerPro
           labels.map(label => (
             <div
               key={label}
-              className="flex items-center gap-1 px-3 py-1 bg-indigo-100 text-indigo-800 rounded-full text-sm"
+              className="flex items-center gap-1 px-3 py-1 bg-primary-100 text-primary-800 rounded-full text-sm"
             >
               <span>{label}</span>
               <button
                 onClick={() => handleRemoveLabel(label)}
-                className="hover:bg-indigo-200 rounded-full p-0.5 transition"
+                className="hover:bg-primary-200 rounded-full p-0.5 transition"
               >
                 <X size={14} />
               </button>

--- a/components/OralFeedbackForm.tsx
+++ b/components/OralFeedbackForm.tsx
@@ -87,7 +87,7 @@ export default function OralFeedbackForm({
         <p className="text-sm text-text-secondary mt-1">{t('oral.subtitle')}</p>
 
         {/* Score Display */}
-        <div className="mt-4 p-4 bg-indigo-50 border-2 border-indigo-200 rounded-lg">
+        <div className="mt-4 p-4 bg-primary-50 border-2 border-primary-200 rounded-lg">
           <div className="flex items-center justify-between">
             <span className="font-semibold text-text-primary">{t('oral.calculatedScore')}:</span>
             <span className="text-3xl font-display font-bold text-brand">{score} / 60</span>
@@ -153,8 +153,8 @@ export default function OralFeedbackForm({
                           onClick={() => updateDimension(dimensionType, { points: p })}
                           className={`w-8 h-8 rounded-lg font-semibold text-sm transition-all ${
                             dimension.points === p
-                              ? 'bg-indigo-600 text-white shadow-md scale-110'
-                              : 'bg-surface border border-border text-text-secondary hover:bg-indigo-50 hover:border-indigo-400'
+                              ? 'bg-primary-600 text-white shadow-md scale-110'
+                              : 'bg-surface border border-border text-text-secondary hover:bg-primary-50 hover:border-primary-400'
                           }`}
                         >
                           {p}

--- a/components/OralTestListPanel.tsx
+++ b/components/OralTestListPanel.tsx
@@ -28,13 +28,13 @@ export default function OralTestListPanel({
     <div className="bg-surface rounded-lg shadow-sm p-6">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
-          <MessageSquare size={24} className="text-indigo-600" />
+          <MessageSquare size={24} className="text-primary-600" />
           <h2 className="text-2xl font-display font-bold text-text-primary">{t('course.oralTests')}</h2>
           <span className="text-text-secondary">({oralTests.length})</span>
         </div>
         <button
           onClick={onAddOralTest}
-          className="flex items-center gap-1 px-3 py-1 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors text-sm"
+          className="flex items-center gap-1 px-3 py-1 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors text-sm"
         >
           <Plus size={16} />
           {t('common.add')}
@@ -61,7 +61,7 @@ export default function OralTestListPanel({
                         <p className="text-xs text-text-secondary">{oralTest.description}</p>
                       )}
                       {oralTest.topics && oralTest.topics.length > 0 && (
-                        <p className="text-xs text-indigo-600 mt-1">
+                        <p className="text-xs text-primary-600 mt-1">
                           {t('course.topics')}: {oralTest.topics.join(', ')}
                         </p>
                       )}
@@ -79,7 +79,7 @@ export default function OralTestListPanel({
                     <div className="flex gap-1">
                       <button
                         onClick={() => onEditOralTest(oralTest)}
-                        className="p-1 text-indigo-600 hover:bg-indigo-50 rounded transition"
+                        className="p-1 text-primary-600 hover:bg-primary-50 rounded transition"
                       >
                         <Edit size={14} />
                       </button>
@@ -93,7 +93,7 @@ export default function OralTestListPanel({
                   </div>
                   <Link
                     href={`/course/${courseId}/oral/${oralTest.id}`}
-                    className="block text-center px-3 py-1 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors text-sm"
+                    className="block text-center px-3 py-1 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors text-sm"
                   >
                     <MessageSquare size={14} className="inline mr-1" />
                     {t('course.giveOralAssessment')}

--- a/components/SnippetPicker.tsx
+++ b/components/SnippetPicker.tsx
@@ -63,7 +63,7 @@ export default function SnippetPicker({
       case 'standard': return 'bg-stone-100 text-stone-700';
       case 'encouragement': return 'bg-emerald-100 text-emerald-700';
       case 'error': return 'bg-rose-100 text-brand-hover';
-      case 'custom': return 'bg-indigo-100 text-indigo-700';
+      case 'custom': return 'bg-primary-100 text-primary-700';
       default: return 'bg-stone-100 text-stone-700';
     }
   };
@@ -81,9 +81,9 @@ export default function SnippetPicker({
       </button>
 
       {isOpen && (
-        <div className="absolute z-50 mt-2 w-80 bg-surface rounded-lg shadow-xl border-2 border-indigo-200 max-h-96 overflow-hidden flex flex-col">
+        <div className="absolute z-50 mt-2 w-80 bg-surface rounded-lg shadow-xl border-2 border-primary-200 max-h-96 overflow-hidden flex flex-col">
           {/* Header */}
-          <div className="p-3 border-b border-border bg-indigo-50">
+          <div className="p-3 border-b border-border bg-primary-50">
             <div className="flex items-center justify-between mb-2">
               <h3 className="font-semibold text-text-primary flex items-center gap-2">
                 <BookmarkPlus size={18} className="text-brand" />
@@ -91,7 +91,7 @@ export default function SnippetPicker({
               </h3>
               <button
                 onClick={() => setIsOpen(false)}
-                className="p-1 hover:bg-indigo-100 rounded transition"
+                className="p-1 hover:bg-primary-100 rounded transition"
               >
                 <X size={16} />
               </button>
@@ -102,7 +102,7 @@ export default function SnippetPicker({
               <button
                 onClick={() => setFilter('all')}
                 className={`px-2 py-1 text-xs rounded transition-colors ${
-                  filter === 'all' ? 'bg-brand text-white' : 'bg-surface text-text-secondary hover:bg-indigo-100'
+                  filter === 'all' ? 'bg-brand text-white' : 'bg-surface text-text-secondary hover:bg-primary-100'
                 }`}
               >
                 Alle ({snippets.length})
@@ -184,7 +184,7 @@ export default function SnippetPicker({
                       if (e.key === 'Escape') setShowAddForm(false);
                     }}
                     placeholder="Skriv inn ny snøggtekst..."
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm text-text-primary"
+                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 text-sm text-text-primary"
                     autoFocus
                   />
                   <div className="flex gap-2">
@@ -208,7 +208,7 @@ export default function SnippetPicker({
               ) : (
                 <button
                   onClick={() => setShowAddForm(true)}
-                  className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-indigo-100 text-indigo-700 rounded-lg hover:bg-indigo-200 transition-colors text-sm"
+                  className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-primary-100 text-primary-700 rounded-lg hover:bg-primary-200 transition-colors text-sm"
                 >
                   <Plus size={16} />
                   Lag ny snøggtekst

--- a/components/SnippetSidebar.tsx
+++ b/components/SnippetSidebar.tsx
@@ -33,7 +33,7 @@ export default function SnippetSidebar({
       case 'standard': return 'bg-stone-100 text-stone-700';
       case 'encouragement': return 'bg-emerald-100 text-emerald-700';
       case 'error': return 'bg-rose-100 text-rose-700';
-      case 'custom': return 'bg-indigo-100 text-indigo-700';
+      case 'custom': return 'bg-primary-100 text-primary-700';
       default: return 'bg-stone-100 text-stone-700';
     }
   };
@@ -176,7 +176,7 @@ export default function SnippetSidebar({
             ) : (
               <button
                 onClick={() => setShowAddForm(true)}
-                className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-indigo-100 text-indigo-700 rounded-lg hover:bg-indigo-200 transition-colors text-sm"
+                className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-primary-100 text-primary-700 rounded-lg hover:bg-primary-200 transition-colors text-sm"
               >
                 <Plus size={16} />
                 {t('snippets.addNew') || 'Lag ny snøggtekst'}

--- a/components/TaskConfiguration.tsx
+++ b/components/TaskConfiguration.tsx
@@ -260,7 +260,7 @@ export default function TaskConfiguration({ tasks, onTasksChange, availableLabel
                         onClick={() => toggleTaskLabel(task.id, label)}
                         className={`px-2 py-0.5 rounded-full text-xs transition ${
                           task.labels.includes(label)
-                            ? 'bg-indigo-600 text-white'
+                            ? 'bg-primary-600 text-white'
                             : 'bg-surface text-text-secondary hover:bg-gray-300 border border-border'
                         }`}
                       >
@@ -329,7 +329,7 @@ export default function TaskConfiguration({ tasks, onTasksChange, availableLabel
                                 onClick={() => toggleSubtaskLabel(task.id, subtask.id, label)}
                                 className={`px-2 py-0.5 rounded-full text-xs transition ${
                                   subtask.labels.includes(label)
-                                    ? 'bg-indigo-600 text-white'
+                                    ? 'bg-primary-600 text-white'
                                     : 'bg-white text-text-secondary hover:bg-gray-200 border border-border'
                                 }`}
                               >
@@ -343,7 +343,7 @@ export default function TaskConfiguration({ tasks, onTasksChange, availableLabel
                   ))}
                   <button
                     onClick={() => addSubtask(task.id)}
-                    className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-brand hover:bg-indigo-50 rounded-lg transition"
+                    className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-brand hover:bg-primary-50 rounded-lg transition"
                   >
                     <Plus size={14} />
                     {t('test.addSubtaskButton')}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,36 +9,108 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        // Modern neutral palette (slate-tinted)
-        background: '#F8FAFC',
-        surface: '#FFFFFF',
-        'surface-alt': '#F1F5F9',
-
-        // Text colors (deeper, richer)
-        'text-primary': '#0F172A',
-        'text-secondary': '#475569',
-        'text-disabled': '#94A3B8',
-
-        // Brand (indigo)
-        brand: {
-          DEFAULT: '#4F46E5',
-          hover: '#4338CA',
-          active: '#3730A3',
+        // Neutral palette (from brand guide)
+        neutral: {
+          900: '#1A1D23',
+          800: '#2C3038',
+          700: '#3E434E',
+          600: '#555B68',
+          500: '#6E7481',
+          400: '#8B919D',
+          300: '#A8ADB6',
+          200: '#C5C8CF',
+          100: '#E2E4E8',
+          50: '#F5F6F8',
         },
 
-        // Semantic colors (refined)
-        success: '#059669',
-        warning: '#D97706',
-        danger: '#DC2626',
-        focus: '#6366F1',
+        // Semantic backgrounds
+        background: '#F5F6F8',
+        surface: '#FFFFFF',
+        'surface-alt': '#E2E4E8',
+
+        // Text colors
+        'text-primary': '#1A1D23',
+        'text-secondary': '#555B68',
+        'text-disabled': '#8B919D',
+
+        // Primary — Deep Teal
+        primary: {
+          900: '#004D4D',
+          800: '#006666',
+          700: '#007F7F',
+          600: '#008585',
+          DEFAULT: '#008B8B',
+          500: '#008B8B',
+          400: '#1A9797',
+          300: '#33A3A3',
+          200: '#66BBBB',
+          100: '#99D3D3',
+          50: '#CCE9E9',
+        },
+
+        // Brand (alias for primary, backward compat)
+        brand: {
+          DEFAULT: '#008B8B',
+          hover: '#007F7F',
+          active: '#006666',
+        },
+
+        // Accent — Warm Coral
+        accent: {
+          900: '#8B3A3A',
+          800: '#A34545',
+          DEFAULT: '#D85A5A',
+          700: '#C05050',
+          600: '#D85A5A',
+          500: '#D85A5A',
+          400: '#DC6B6B',
+          300: '#E07B7B',
+          200: '#E89C9C',
+          100: '#F0BDBD',
+          50: '#F8DEDE',
+        },
+
+        // Functional — Links
+        link: {
+          DEFAULT: '#6B46C1',
+          hover: '#553C9A',
+          visited: '#9333EA',
+        },
+
+        // Functional — Highlight
+        highlight: {
+          DEFAULT: '#FBBF24',
+          bg: '#FEF3C7',
+        },
+
+        // Semantic colors
+        success: {
+          DEFAULT: '#10B981',
+          bg: '#D1FAE5',
+        },
+        warning: {
+          DEFAULT: '#F59E0B',
+          bg: '#FEF3C7',
+        },
+        danger: {
+          DEFAULT: '#DC2626',
+          bg: '#FEE2E2',
+        },
+        info: {
+          DEFAULT: '#3B82F6',
+          bg: '#DBEAFE',
+        },
+
+        focus: '#008B8B',
       },
       borderColor: {
-        DEFAULT: '#E2E8F0',
-        border: '#E2E8F0',
+        DEFAULT: '#C5C8CF',
+        border: '#C5C8CF',
       },
       fontFamily: {
-        sans: ['Inter', 'SF Pro Text', 'Segoe UI', 'Roboto', 'Helvetica', 'Arial', 'sans-serif'],
-        display: ['Satoshi', 'Inter', 'sans-serif'],
+        sans: ['Source Sans 3', 'Source Sans Pro', 'system-ui', 'sans-serif'],
+        display: ['Roboto Slab', 'Georgia', 'serif'],
+        mono: ['JetBrains Mono', 'Fira Code', 'monospace'],
       },
     },
   },


### PR DESCRIPTION
- Replace indigo brand colors with deep teal (#008B8B) primary palette
- Add warm coral (#D85A5A) accent color scale
- Add full neutral gray scale from brand guide
- Add functional colors: purple links, golden highlights, info/success/warning/error with background variants
- Switch fonts: Source Sans 3 (body), Roboto Slab (headings), JetBrains Mono (code)
- Load all three fonts via Google Fonts CDN link
- Update globals.css with base styles for code elements and link colors
- Replace all indigo-* Tailwind classes with primary-* across 16 component files
- Update border color to neutral-200 (#C5C8CF)

https://claude.ai/code/session_018i84mTrhZWZ82kVGxurBdB