### PR TITLE
Fix font-family quoting for multi-word font names

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -108,9 +108,9 @@ const config: Config = {
         border: '#C5C8CF',
       },
       fontFamily: {
-        sans: ['Source Sans 3', 'Source Sans Pro', 'system-ui', 'sans-serif'],
-        display: ['Roboto Slab', 'Georgia', 'serif'],
-        mono: ['JetBrains Mono', 'Fira Code', 'monospace'],
+        sans: ['"Source Sans 3"', '"Source Sans Pro"', 'system-ui', 'sans-serif'],
+        display: ['"Roboto Slab"', 'Georgia', 'serif'],
+        mono: ['"JetBrains Mono"', '"Fira Code"', 'monospace'],
       },
     },
   },


### PR DESCRIPTION
Tailwind does not auto-escape font family names containing spaces. Without inner quotes, 'Source Sans 3' generated invalid CSS (three separate identifiers instead of one font name), causing the browser to fall back to system-ui.

https://claude.ai/code/session_018i84mTrhZWZ82kVGxurBdB