### PR TITLE
Switch body font from Source Sans 3 to Source Sans Pro

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 :root {
-  --font-source-sans: 'Source Sans 3', 'Source Sans Pro', system-ui, sans-serif;
+  --font-source-sans: 'Source Sans Pro', 'Source Sans 3', system-ui, sans-serif;
   --font-roboto-slab: 'Roboto Slab', Georgia, serif;
   --font-jetbrains-mono: 'JetBrains Mono', 'Fira Code', monospace;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
-          href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,400;1,600&family=Roboto+Slab:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,400;1,600&family=Roboto+Slab:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
           rel="stylesheet"
         />
       </head>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -108,7 +108,7 @@ const config: Config = {
         border: '#C5C8CF',
       },
       fontFamily: {
-        sans: ['"Source Sans 3"', '"Source Sans Pro"', 'system-ui', 'sans-serif'],
+        sans: ['"Source Sans Pro"', '"Source Sans 3"', 'system-ui', 'sans-serif'],
         display: ['"Roboto Slab"', 'Georgia', 'serif'],
         mono: ['"JetBrains Mono"', '"Fira Code"', 'monospace'],
       },


### PR DESCRIPTION
Source Sans 3 wasn't loading from Google Fonts. Use Source Sans Pro (the widely available predecessor) as the primary body font, with Source Sans 3 as fallback.

https://claude.ai/code/session_018i84mTrhZWZ82kVGxurBdB