### PR TITLE
Add inline tag/label creation in test settings task configuration

### DIFF
--- a/app/course/[courseId]/test/[testId]/page.tsx
+++ b/app/course/[courseId]/test/[testId]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { Course, CourseTest, CourseStudent, TaskFeedback, TestFeedbackData, FeedbackSnippet } from '@/types';
-import { loadCourse, updateTest, updateStudentFeedback, getStudentFeedback, calculateStudentScore } from '@/utils/courseStorage';
+import { loadCourse, updateCourse, updateTest, updateStudentFeedback, getStudentFeedback, calculateStudentScore } from '@/utils/courseStorage';
 import { generateTypstDocument, downloadTypstFile, compileAndDownloadPDF } from '@/utils/typstExport';
 import TaskConfiguration from '@/components/TaskConfiguration';
 import SnippetPicker from '@/components/SnippetPicker';
@@ -129,6 +129,12 @@ export default function TestFeedbackPage() {
       toast(t('test.testConfigSaved'), 'success');
       loadData();
     }
+  };
+
+  const handleLabelsChange = (labels: string[]) => {
+    updateCourse(courseId, { availableLabels: labels });
+    setCourse(prev => prev ? { ...prev, availableLabels: labels } : prev);
+    setHasUnsavedTestConfig(true);
   };
 
   const handleUpdateFeedback = (taskId: string, subtaskId: string | undefined, updates: Partial<TaskFeedback>) => {
@@ -588,6 +594,7 @@ export default function TestFeedbackPage() {
               tasks={test.tasks}
               onTasksChange={(tasks) => handleTestChange({ ...test, tasks })}
               availableLabels={course.availableLabels}
+              onLabelsChange={handleLabelsChange}
             />
           </div>
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -286,7 +286,9 @@
     "backToStudentGrading": "Student Grading",
     "taskOverview": "Task Overview",
     "noComment": "No comment",
-    "notAttempted": "Not attempted"
+    "notAttempted": "Not attempted",
+    "addLabelInline": "New",
+    "newLabelPlaceholder": "e.g., logarithms"
   },
   "oral": {
     "title": "Oral Assessment",

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -286,7 +286,9 @@
     "backToStudentGrading": "Elevretting",
     "taskOverview": "Oppgaveoversikt",
     "noComment": "Ingen kommentar",
-    "notAttempted": "Ikke forsøkt"
+    "notAttempted": "Ikke forsøkt",
+    "addLabelInline": "Ny",
+    "newLabelPlaceholder": "f.eks. logaritmer"
   },
   "oral": {
     "title": "Muntlig vurdering",

--- a/locales/nn.json
+++ b/locales/nn.json
@@ -286,7 +286,9 @@
     "backToStudentGrading": "Elevretting",
     "taskOverview": "Oppgåveoversikt",
     "noComment": "Ingen kommentar",
-    "notAttempted": "Ikkje forsøkt"
+    "notAttempted": "Ikkje forsøkt",
+    "addLabelInline": "Ny",
+    "newLabelPlaceholder": "t.d. logaritmar"
   },
   "oral": {
     "title": "Munnleg vurdering",


### PR DESCRIPTION
Allow adding new course labels directly from the test settings page instead of requiring navigation back to the course page. Each task and subtask theme row now has a "+ New" button that opens an inline input. New labels are saved to the course and auto-toggled on the target task.

https://claude.ai/code/session_01BY8AuXV33oiXgSW7ciWpp1