### PR TITLE
Phase 3: Add test coverage for sync, backup, and import-export

### DIFF
--- a/__tests__/backup.test.ts
+++ b/__tests__/backup.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    createBackup,
+    listBackups,
+    restoreFromBackup,
+    deleteBackup,
+    startAutoBackup,
+    stopAutoBackup,
+    isAutoBackupRunning,
+    loadAllCourses,
+    saveCourse,
+    safeDeleteCourse,
+} from '@/utils/storage';
+import { Course } from '@/types';
+
+// ─── test helpers ─────────────────────────────────────────────────
+
+function makeCourse(id: string, name: string, opts: {
+    completedFeedbacks?: number;
+} = {}): Course {
+    const studentFeedbacks = Array.from(
+        { length: opts.completedFeedbacks ?? 0 },
+        (_, i) => ({
+            studentId: `s${i}`,
+            taskFeedbacks: [],
+            individualComment: '',
+            completedDate: '2026-01-01T00:00:00Z',
+        })
+    );
+
+    return {
+        id,
+        name,
+        description: '',
+        students: [{ id: 's1', name: 'Alice', studentNumber: '1' }],
+        tests: [{
+            id: 'test1',
+            name: 'Test 1',
+            date: '2026-01-01',
+            tasks: [],
+            studentFeedbacks,
+            createdDate: '2026-01-01T00:00:00Z',
+            lastModified: '2026-01-01T00:00:00Z',
+            hasTwoParts: false,
+        }],
+        createdDate: '2026-01-01T00:00:00Z',
+        lastModified: '2026-01-01T00:00:00Z',
+        availableLabels: [],
+    };
+}
+
+// ─── setup / teardown ─────────────────────────────────────────────
+
+function clearStorage() {
+    const keys: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key) keys.push(key);
+    }
+    keys.forEach(k => localStorage.removeItem(k));
+}
+
+beforeEach(() => {
+    clearStorage();
+    stopAutoBackup();
+});
+
+afterEach(() => {
+    stopAutoBackup();
+    vi.useRealTimers();
+});
+
+// ─── createBackup ─────────────────────────────────────────────────
+
+describe('createBackup', () => {
+    it('returns null when no courses exist', () => {
+        expect(createBackup('manual')).toBeNull();
+    });
+
+    it('creates a backup entry with correct metadata', () => {
+        saveCourse(makeCourse('c1', 'Math 101', { completedFeedbacks: 2 }));
+
+        const entry = createBackup('manual');
+        expect(entry).not.toBeNull();
+        expect(entry!.courseCount).toBe(1);
+        expect(entry!.totalFeedback).toBe(2);
+        expect(entry!.label).toBe('manual');
+        expect(entry!.sizeBytes).toBeGreaterThan(0);
+    });
+
+    it('trims backups to MAX_BACKUPS (10)', () => {
+        saveCourse(makeCourse('c1', 'Math 101'));
+
+        // create 12 backups — should keep only 10
+        for (let i = 0; i < 12; i++) {
+            createBackup('auto');
+        }
+
+        const backups = listBackups();
+        expect(backups.length).toBeLessThanOrEqual(10);
+    });
+});
+
+// ─── listBackups ──────────────────────────────────────────────────
+
+describe('listBackups', () => {
+    it('returns empty array when no backups exist', () => {
+        expect(listBackups()).toEqual([]);
+    });
+
+    it('returns all created backups', () => {
+        saveCourse(makeCourse('c1', 'Math'));
+
+        createBackup('first');
+        createBackup('second');
+        createBackup('third');
+
+        const backups = listBackups();
+        expect(backups).toHaveLength(3);
+        const labels = backups.map(b => b.label);
+        expect(labels).toContain('first');
+        expect(labels).toContain('second');
+        expect(labels).toContain('third');
+    });
+});
+
+// ─── restoreFromBackup ────────────────────────────────────────────
+
+describe('restoreFromBackup', () => {
+    it('restores courses from a backup', () => {
+        // Create initial state and backup
+        saveCourse(makeCourse('c1', 'Math'));
+        saveCourse(makeCourse('c2', 'Science'));
+        const backup = createBackup('manual')!;
+
+        // Delete a course
+        localStorage.setItem('math-feedback-courses', JSON.stringify([makeCourse('c1', 'Math')]));
+        expect(loadAllCourses()).toHaveLength(1);
+
+        // Restore
+        const result = restoreFromBackup(backup.id);
+        expect(result.success).toBe(true);
+        expect(result.courseCount).toBe(2);
+        expect(loadAllCourses()).toHaveLength(2);
+    });
+
+    it('returns failure for non-existent backup', () => {
+        const result = restoreFromBackup('nonexistent-id');
+        expect(result.success).toBe(false);
+        expect(result.courseCount).toBe(0);
+    });
+
+    it('creates safety backup before restoring', () => {
+        saveCourse(makeCourse('c1', 'Math'));
+        const originalBackup = createBackup('manual')!;
+
+        // Modify state
+        saveCourse(makeCourse('c2', 'New Course'));
+
+        restoreFromBackup(originalBackup.id);
+
+        // Should have more backups now (original + before-restore)
+        const backups = listBackups();
+        const safetyBackup = backups.find(b => b.label === 'before-restore');
+        expect(safetyBackup).toBeDefined();
+    });
+});
+
+// ─── deleteBackup ─────────────────────────────────────────────────
+
+describe('deleteBackup', () => {
+    it('removes a backup from the index and localStorage', () => {
+        saveCourse(makeCourse('c1', 'Math'));
+        const backup = createBackup('manual')!;
+
+        expect(listBackups()).toHaveLength(1);
+        deleteBackup(backup.id);
+        expect(listBackups()).toHaveLength(0);
+    });
+});
+
+// ─── autoBackup ───────────────────────────────────────────────────
+
+describe('autoBackup', () => {
+    it('starts and stops correctly', () => {
+        saveCourse(makeCourse('c1', 'Math'));
+
+        expect(isAutoBackupRunning()).toBe(false);
+        startAutoBackup();
+        expect(isAutoBackupRunning()).toBe(true);
+
+        // Should have created an initial backup
+        expect(listBackups().length).toBeGreaterThanOrEqual(1);
+
+        stopAutoBackup();
+        expect(isAutoBackupRunning()).toBe(false);
+    });
+
+    it('does not start a second timer if already running', () => {
+        saveCourse(makeCourse('c1', 'Math'));
+
+        startAutoBackup();
+        startAutoBackup(); // should be a no-op
+        expect(isAutoBackupRunning()).toBe(true);
+
+        stopAutoBackup();
+        expect(isAutoBackupRunning()).toBe(false);
+    });
+});
+
+// ─── safeDeleteCourse ─────────────────────────────────────────────
+
+describe('safeDeleteCourse', () => {
+    it('creates a backup before deleting', () => {
+        saveCourse(makeCourse('c1', 'Math'));
+        saveCourse(makeCourse('c2', 'Science'));
+
+        const { backupId } = safeDeleteCourse('c1');
+        expect(backupId).not.toBeNull();
+        expect(loadAllCourses()).toHaveLength(1);
+        expect(loadAllCourses()[0].name).toBe('Science');
+
+        // Backup exists and contains the deleted course
+        const backups = listBackups();
+        expect(backups.some(b => b.label === 'before-delete')).toBe(true);
+    });
+});

--- a/__tests__/import-export.test.ts
+++ b/__tests__/import-export.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    exportAllCourses,
+    importCourses,
+    importCoursesFromData,
+    validateCourseData,
+    loadAllCourses,
+    saveCourse,
+} from '@/utils/storage';
+import { Course } from '@/types';
+
+// ─── helpers ──────────────────────────────────────────────────────
+
+function makeCourse(id: string, name: string, opts: {
+    students?: { id: string; name: string; studentNumber: string }[];
+    tests?: { id: string; name: string }[];
+    labels?: string[];
+} = {}): Course {
+    return {
+        id,
+        name,
+        description: '',
+        students: opts.students ?? [{ id: 's1', name: 'Alice', studentNumber: '1' }],
+        tests: (opts.tests ?? [{ id: 'test1', name: 'Test 1' }]).map(t => ({
+            ...t,
+            date: '2026-01-01',
+            tasks: [],
+            studentFeedbacks: [],
+            createdDate: '2026-01-01T00:00:00Z',
+            lastModified: '2026-01-01T00:00:00Z',
+            hasTwoParts: false,
+        })),
+        createdDate: '2026-01-01T00:00:00Z',
+        lastModified: '2026-01-01T00:00:00Z',
+        availableLabels: opts.labels ?? [],
+    };
+}
+
+// ─── setup ────────────────────────────────────────────────────────
+
+function clearStorage() {
+    const keys: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key) keys.push(key);
+    }
+    keys.forEach(k => localStorage.removeItem(k));
+}
+
+beforeEach(() => {
+    clearStorage();
+});
+
+// ─── validateCourseData ───────────────────────────────────────────
+
+describe('validateCourseData', () => {
+    it('validates a correct course', () => {
+        const result = validateCourseData(makeCourse('c1', 'Math'));
+        expect(result.valid).toBe(true);
+        expect(result.errors).toHaveLength(0);
+    });
+
+    it('validates an array of courses', () => {
+        const result = validateCourseData([makeCourse('c1', 'Math'), makeCourse('c2', 'Science')]);
+        expect(result.valid).toBe(true);
+    });
+
+    it('rejects null/undefined', () => {
+        expect(validateCourseData(null).valid).toBe(false);
+        expect(validateCourseData(undefined).valid).toBe(false);
+    });
+
+    it('rejects course without name', () => {
+        const result = validateCourseData({ students: [], tests: [] });
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain('name');
+    });
+
+    it('rejects course without students array', () => {
+        const result = validateCourseData({ name: 'Math', tests: [] });
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain('students');
+    });
+
+    it('rejects course without tests array', () => {
+        const result = validateCourseData({ name: 'Math', students: [] });
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain('tests');
+    });
+});
+
+// ─── exportAllCourses ─────────────────────────────────────────────
+
+describe('exportAllCourses', () => {
+    it('returns empty array JSON when no courses', () => {
+        expect(exportAllCourses()).toBe('[]');
+    });
+
+    it('exports all courses as formatted JSON', () => {
+        saveCourse(makeCourse('c1', 'Math'));
+        saveCourse(makeCourse('c2', 'Science'));
+
+        const exported = exportAllCourses();
+        const parsed = JSON.parse(exported);
+        expect(parsed).toHaveLength(2);
+        expect(parsed[0].name).toBe('Math');
+        expect(parsed[1].name).toBe('Science');
+    });
+});
+
+// ─── round-trip ───────────────────────────────────────────────────
+
+describe('export → import round-trip', () => {
+    it('preserves data through export and re-import', () => {
+        const original = makeCourse('c1', 'Algebra', {
+            students: [
+                { id: 's1', name: 'Alice', studentNumber: '1' },
+                { id: 's2', name: 'Bob', studentNumber: '2' },
+            ],
+            labels: ['equations', 'geometry'],
+        });
+        saveCourse(original);
+
+        const exported = exportAllCourses();
+
+        // Clear and re-import
+        clearStorage();
+        expect(loadAllCourses()).toHaveLength(0);
+
+        const result = importCourses(exported);
+        expect(result.imported).toBe(1);
+        expect(result.errors).toHaveLength(0);
+
+        const courses = loadAllCourses();
+        expect(courses).toHaveLength(1);
+        expect(courses[0].name).toBe('Algebra');
+        expect(courses[0].students).toHaveLength(2);
+        expect(courses[0].availableLabels).toEqual(['equations', 'geometry']);
+    });
+});
+
+// ─── importCourses ────────────────────────────────────────────────
+
+describe('importCourses', () => {
+    it('rejects invalid JSON', () => {
+        const result = importCourses('not json!!!');
+        expect(result.errors).toContain('Invalid JSON format');
+        expect(result.imported).toBe(0);
+    });
+
+    it('imports a new course', () => {
+        const json = JSON.stringify(makeCourse('c1', 'Math'));
+        const result = importCourses(json);
+        expect(result.imported).toBe(1);
+        expect(loadAllCourses()).toHaveLength(1);
+    });
+
+    it('imports an array of courses', () => {
+        const json = JSON.stringify([makeCourse('c1', 'Math'), makeCourse('c2', 'Science')]);
+        const result = importCourses(json);
+        expect(result.imported).toBe(2);
+    });
+
+    it('skips duplicates by default (same ID)', () => {
+        saveCourse(makeCourse('c1', 'Math'));
+        const json = JSON.stringify(makeCourse('c1', 'Math'));
+
+        const result = importCourses(json);
+        expect(result.skippedDuplicates).toBe(1);
+        expect(result.imported).toBe(0);
+        expect(loadAllCourses()).toHaveLength(1);
+    });
+
+    it('skips duplicates by name (case-insensitive)', () => {
+        saveCourse(makeCourse('c1', 'Math'));
+        const json = JSON.stringify(makeCourse('c99', 'MATH')); // different ID, same name
+
+        const result = importCourses(json);
+        expect(result.skippedDuplicates).toBe(1);
+    });
+
+    it('force-imports duplicates with skipDuplicates=false', () => {
+        saveCourse(makeCourse('c1', 'Math'));
+        const json = JSON.stringify(makeCourse('c1', 'Math'));
+
+        const result = importCourses(json, { skipDuplicates: false });
+        expect(result.imported).toBe(1);
+        // Should have 2 courses (original + renamed import)
+        const courses = loadAllCourses();
+        expect(courses).toHaveLength(2);
+        expect(courses[1].name).toContain('(imported)');
+    });
+
+    it('merges students and tests with mergeExisting=true', () => {
+        // Existing course with Alice
+        saveCourse(makeCourse('c1', 'Math', {
+            students: [{ id: 's1', name: 'Alice', studentNumber: '1' }],
+            tests: [{ id: 'test1', name: 'Test 1' }],
+            labels: ['algebra'],
+        }));
+
+        // Import same course with Bob and a new test
+        const incoming = makeCourse('c1', 'Math', {
+            students: [
+                { id: 's1', name: 'Alice', studentNumber: '1' },
+                { id: 's2', name: 'Bob', studentNumber: '2' },
+            ],
+            tests: [{ id: 'test1', name: 'Test 1' }, { id: 'test2', name: 'Test 2' }],
+            labels: ['algebra', 'geometry'],
+        });
+
+        const result = importCourses(JSON.stringify(incoming), { mergeExisting: true });
+        expect(result.merged).toBe(1);
+
+        const courses = loadAllCourses();
+        expect(courses).toHaveLength(1);
+        expect(courses[0].students).toHaveLength(2); // Alice + Bob
+        expect(courses[0].tests).toHaveLength(2);    // Test 1 + Test 2
+        expect(courses[0].availableLabels).toContain('geometry');
+    });
+
+    it('generates ID for course without one', () => {
+        const course = makeCourse('', 'No-ID Course');
+        course.id = '';  // explicitly empty
+        const json = JSON.stringify(course);
+
+        const result = importCourses(json);
+        expect(result.imported).toBe(1);
+
+        const courses = loadAllCourses();
+        expect(courses[0].id).toBeTruthy(); // should have generated an ID
+    });
+});
+
+// ─── importCoursesFromData ────────────────────────────────────────
+
+describe('importCoursesFromData', () => {
+    it('wraps importCourses with object input', () => {
+        const course = makeCourse('c1', 'Math');
+        const result = importCoursesFromData([course]);
+        expect(result.imported).toBe(1);
+        expect(loadAllCourses()).toHaveLength(1);
+    });
+});

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,0 +1,32 @@
+// Setup file to ensure localStorage works correctly in all tests.
+// Vitest's jsdom sometimes provides a broken localStorage implementation.
+
+const store = new Map<string, string>();
+
+const localStorageMock: Storage = {
+    getItem(key: string): string | null {
+        return store.get(key) ?? null;
+    },
+    setItem(key: string, value: string): void {
+        store.set(key, value);
+    },
+    removeItem(key: string): void {
+        store.delete(key);
+    },
+    clear(): void {
+        store.clear();
+    },
+    get length(): number {
+        return store.size;
+    },
+    key(index: number): string | null {
+        const keys = Array.from(store.keys());
+        return keys[index] ?? null;
+    },
+};
+
+Object.defineProperty(globalThis, 'localStorage', {
+    value: localStorageMock,
+    writable: true,
+    configurable: true,
+});

--- a/__tests__/sync.test.ts
+++ b/__tests__/sync.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mergeFeedbacks, mergeTests } from '@/utils/storage';
+import { TestFeedbackData, CourseTest } from '@/types';
+
+// ─── helpers ──────────────────────────────────────────────────────
+
+function makeFb(
+    studentId: string,
+    taskCount: number,
+    opts: { completed?: boolean; comment?: string } = {}
+): TestFeedbackData {
+    return {
+        studentId,
+        taskFeedbacks: Array.from({ length: taskCount }, (_, i) => ({
+            taskId: `t${i}`,
+            points: 3,
+            comment: '',
+        })),
+        individualComment: opts.comment ?? '',
+        completedDate: opts.completed ? '2026-01-01T00:00:00Z' : undefined,
+    };
+}
+
+function makeTest(
+    id: string,
+    feedbacks: TestFeedbackData[] = [],
+    modified = '2026-01-01T00:00:00Z'
+): CourseTest {
+    return {
+        id,
+        name: `Test ${id}`,
+        date: '2026-01-01',
+        tasks: [],
+        studentFeedbacks: feedbacks,
+        createdDate: '2026-01-01T00:00:00Z',
+        lastModified: modified,
+        hasTwoParts: false,
+    };
+}
+
+// ─── mergeFeedbacks ───────────────────────────────────────────────
+
+describe('mergeFeedbacks', () => {
+    it('keeps all local feedback when folder is empty', () => {
+        const local = [makeFb('s1', 3), makeFb('s2', 2)];
+        const result = mergeFeedbacks(local, []);
+        expect(result).toHaveLength(2);
+        expect(result.map(f => f.studentId).sort()).toEqual(['s1', 's2']);
+    });
+
+    it('adds folder-only students', () => {
+        const local = [makeFb('s1', 2)];
+        const folder = [makeFb('s3', 4)];
+        const result = mergeFeedbacks(local, folder);
+        expect(result).toHaveLength(2);
+        expect(result.find(f => f.studentId === 's3')!.taskFeedbacks).toHaveLength(4);
+    });
+
+    it('keeps local in-progress work over empty folder entry', () => {
+        const local = [makeFb('s1', 3)];               // in-progress, 3 tasks graded
+        const folder = [makeFb('s1', 0)];               // empty in folder
+        const result = mergeFeedbacks(local, folder);
+        expect(result).toHaveLength(1);
+        expect(result[0].taskFeedbacks).toHaveLength(3); // kept local
+    });
+
+    it('takes folder data when local is empty', () => {
+        const local = [makeFb('s1', 0)];                // empty local
+        const folder = [makeFb('s1', 5)];               // folder has data
+        const result = mergeFeedbacks(local, folder);
+        expect(result[0].taskFeedbacks).toHaveLength(5); // used folder
+    });
+
+    it('prefers completed over not-completed (folder completed)', () => {
+        const local = [makeFb('s1', 2)];                     // 2 tasks, not completed
+        const folder = [makeFb('s1', 3, { completed: true })]; // 3 tasks, completed
+        const result = mergeFeedbacks(local, folder);
+        expect(result[0].completedDate).toBeDefined();
+        expect(result[0].taskFeedbacks).toHaveLength(3);
+    });
+
+    it('keeps local with more feedbacks even if folder is completed', () => {
+        const local = [makeFb('s1', 5)];                     // 5 tasks (more work)
+        const folder = [makeFb('s1', 3, { completed: true })]; // 3 tasks, completed
+        const result = mergeFeedbacks(local, folder);
+        // Local has MORE tasks → keep it despite folder being completed
+        expect(result[0].taskFeedbacks).toHaveLength(5);
+    });
+
+    it('prefers completed local over not-completed folder', () => {
+        const local = [makeFb('s1', 3, { completed: true })];
+        const folder = [makeFb('s1', 2)];
+        const result = mergeFeedbacks(local, folder);
+        expect(result[0].completedDate).toBeDefined();
+        expect(result[0].taskFeedbacks).toHaveLength(3);
+    });
+
+    it('prefers more data when both have same completion status', () => {
+        const local = [makeFb('s1', 2)];
+        const folder = [makeFb('s1', 5)];  // folder has more
+        const result = mergeFeedbacks(local, folder);
+        expect(result[0].taskFeedbacks).toHaveLength(5);
+    });
+
+    it('keeps local when both have same count and same completion', () => {
+        const local = [makeFb('s1', 3, { comment: 'local-comment' })];
+        const folder = [makeFb('s1', 3, { comment: 'folder-comment' })];
+        const result = mergeFeedbacks(local, folder);
+        // Same count → local wins (no replacement happens)
+        expect(result[0].individualComment).toBe('local-comment');
+    });
+
+    it('considers individualComment as "has data"', () => {
+        const local = [makeFb('s1', 0, { comment: 'working on it' })];
+        const folder = [makeFb('s1', 0)]; // empty
+        const result = mergeFeedbacks(local, folder);
+        // Local has comment = has data, folder doesn't → keep local
+        expect(result[0].individualComment).toBe('working on it');
+    });
+
+    it('handles many students from both sources', () => {
+        const local = [makeFb('s1', 1), makeFb('s2', 1)];
+        const folder = [makeFb('s2', 2), makeFb('s3', 1)];
+        const result = mergeFeedbacks(local, folder);
+        expect(result).toHaveLength(3);  // s1, s2, s3
+        // s2: folder has more → use folder
+        expect(result.find(f => f.studentId === 's2')!.taskFeedbacks).toHaveLength(2);
+    });
+});
+
+// ─── mergeTests ───────────────────────────────────────────────────
+
+describe('mergeTests', () => {
+    it('keeps all local tests when folder is empty', () => {
+        const local = [makeTest('t1'), makeTest('t2')];
+        const result = mergeTests(local, []);
+        expect(result).toHaveLength(2);
+    });
+
+    it('adds folder-only tests', () => {
+        const local = [makeTest('t1')];
+        const folder = [makeTest('t2')];
+        const result = mergeTests(local, folder);
+        expect(result).toHaveLength(2);
+    });
+
+    it('merges feedbacks for overlapping tests', () => {
+        const local = [makeTest('t1', [makeFb('s1', 3)])];
+        const folder = [makeTest('t1', [makeFb('s2', 4)])];
+        const result = mergeTests(local, folder);
+        expect(result).toHaveLength(1);
+        expect(result[0].studentFeedbacks).toHaveLength(2);
+    });
+
+    it('uses newer test config when test exists in both', () => {
+        const local = [makeTest('t1', [], '2026-01-01T00:00:00Z')];
+        const folder = [makeTest('t1', [], '2026-02-01T00:00:00Z')];
+        // Folder is newer → use folder's config (name, tasks, etc.)
+        // This test just ensures no crash; actual config preference is based on lastModified
+        const result = mergeTests(local, folder);
+        expect(result).toHaveLength(1);
+    });
+
+    it('handles empty inputs', () => {
+        expect(mergeTests([], [])).toEqual([]);
+    });
+});

--- a/utils/storage/courseStorage.ts
+++ b/utils/storage/courseStorage.ts
@@ -963,7 +963,7 @@ export function getTaskStudentScores(
  * or the one with a completedDate if the other doesn't have one).
  * Never discard in-progress feedback.
  */
-function mergeFeedbacks(
+export function mergeFeedbacks(
   localFeedbacks: TestFeedbackData[],
   folderFeedbacks: TestFeedbackData[]
 ): TestFeedbackData[] {
@@ -1022,7 +1022,7 @@ function mergeFeedbacks(
  * Merge tests: union-merge by test id.
  * For each test, merge their studentFeedbacks.
  */
-function mergeTests(
+export function mergeTests(
   localTests: CourseTest[],
   folderTests: CourseTest[]
 ): CourseTest[] {

--- a/utils/storage/index.ts
+++ b/utils/storage/index.ts
@@ -49,6 +49,8 @@ export {
     // Folder sync
     syncFromFolder,
     migrateToFolder,
+    mergeFeedbacks,
+    mergeTests,
 
     // Backup system
     createBackup,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    setupFiles: [],
+    setupFiles: ['./__tests__/setup.ts'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
- sync.test.ts: 16 tests for mergeFeedbacks and mergeTests logic
- backup.test.ts: 12 tests for backup create/list/restore/delete/auto
- import-export.test.ts: 18 tests for validation, round-trip, duplicate modes
- setup.ts: localStorage mock for vitest jsdom environment
- Export mergeFeedbacks/mergeTests for direct unit testing
- All 84 tests pass across 6 suites